### PR TITLE
chore: add Rust syntax highlighting for .no files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Syntax highlighting of .no files as Rust
+*.no linguist-language=Rust


### PR DESCRIPTION
Add simple syntax highlighting based on Rust to prettify things. To see how it looks like, check [my fork](https://github.com/eightfilms/noname/tree/main/examples)