### PR TITLE
feat: add syntax highlighting for GitHub web viewer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.no linguist-language=Rust


### PR DESCRIPTION
By using `.gitattributes` we can let GitHub treat `.no` files as `.rust` files, therefore enable syntax highlighting within the example codes. Note that this will also count `.no` files LOC as Rust LOC as well, contributing to overall percentage as appears at <https://github.com/search?q=repo%3Azksecurity%2Fnoname++language%3ARust&type=code>

See live example <https://github.com/erhant/noname/blob/main/examples/sudoku.no>