### PR TITLE
chore(ci): update CI to use dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,9 +15,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Rust Documentation
-        run: |
-          rustup install nightly
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps
+        uses: dtolnay/rust-toolchain@nightly
+        run: RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps
 
       - name: Build the mdbook
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,10 +27,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up cargo/rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: "1.63.0"
           components: rustfmt, clippy
 
       # https://github.com/Swatinem/rust-cache
@@ -45,20 +43,14 @@ jobs:
       # 
 
       - name: Test with latest nextest release (faster than cargo test)
-        uses: actions-rs/cargo@v1
-        with:            
-          command: nextest
-          args: run --all-features --release
+        run: cargo nextest run --all-features --release
 
       #
       # Coding guidelines
       #
 
-      - name: Enforce formating
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - name: Enforce formatting
+        run: cargo fmt -- --check
 
       # - name: Lint (clippy)
       #   uses: actions-rs/cargo@v1


### PR DESCRIPTION
The actions-rs cargo repository has been [archived](https://github.com/actions-rs/cargo), so this PR just updates the CI to use [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) instead. It also has a more concise one-line usage with sane defaults.