### PR TITLE
chore: fix all lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Enforce formatting
         run: cargo fmt -- --check
 
-      - name: Lint (clippy)
-        run: cargo clippy --all-features -- -D warnings
+      # - name: Lint (clippy)
+      #   run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,8 +52,5 @@ jobs:
       - name: Enforce formatting
         run: cargo fmt -- --check
 
-      # - name: Lint (clippy)
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: clippy
-      #     args: --all-features -- -D warnings
+      - name: Lint (clippy)
+        run: cargo clippy --all-features -- -D warnings

--- a/src/backends/kimchi/asm.rs
+++ b/src/backends/kimchi/asm.rs
@@ -22,7 +22,6 @@
 //!
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::Write;
 use std::hash::Hash;
 
 use crate::helpers::PrettyField;
@@ -38,6 +37,7 @@ pub fn extract_vars_from_coeffs(vars: &mut OrderedHashSet<VestaField>, coeffs: &
     }
 }
 
+#[must_use]
 pub fn parse_coeffs(vars: &OrderedHashSet<VestaField>, coeffs: &[VestaField]) -> Vec<String> {
     let mut coeffs: Vec<_> = coeffs
         .iter()
@@ -90,10 +90,12 @@ where
         self.map[value]
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.ordered.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.ordered.is_empty()
     }

--- a/src/backends/kimchi/asm.rs
+++ b/src/backends/kimchi/asm.rs
@@ -37,7 +37,6 @@ pub fn extract_vars_from_coeffs(vars: &mut OrderedHashSet<VestaField>, coeffs: &
     }
 }
 
-#[must_use]
 pub fn parse_coeffs(vars: &OrderedHashSet<VestaField>, coeffs: &[VestaField]) -> Vec<String> {
     let mut coeffs: Vec<_> = coeffs
         .iter()
@@ -90,12 +89,10 @@ where
         self.map[value]
     }
 
-    #[must_use]
     pub fn len(&self) -> usize {
         self.ordered.len()
     }
 
-    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.ordered.is_empty()
     }

--- a/src/backends/kimchi/builtin.rs
+++ b/src/backends/kimchi/builtin.rs
@@ -172,7 +172,7 @@ pub fn poseidon(
     let vars = final_row
         .iter()
         .flatten()
-        .cloned()
+        .copied()
         .map(ConstOrCell::Cell)
         .collect();
 

--- a/src/backends/kimchi/builtin.rs
+++ b/src/backends/kimchi/builtin.rs
@@ -172,7 +172,7 @@ pub fn poseidon(
     let vars = final_row
         .iter()
         .flatten()
-        .copied()
+        .cloned()
         .map(ConstOrCell::Cell)
         .collect();
 

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -126,7 +126,7 @@ impl Witness {
 
     pub fn debug(&self) {
         for (row, values) in self.0.iter().enumerate() {
-            let values = values.iter().map(PrettyField::pretty).join(" | ");
+            let values = values.iter().map(PrettyField).join(" | ");
             println!("{row} - {values}");
         }
     }

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -103,7 +103,6 @@ pub struct KimchiVesta {
 
 impl Witness {
     /// kimchi uses a transposed witness
-    #[must_use]
     pub fn to_kimchi_witness(&self) -> [Vec<VestaField>; NUM_REGISTERS] {
         let transposed = (0..NUM_REGISTERS)
             .map(|_| Vec::with_capacity(self.0.len()))
@@ -117,12 +116,10 @@ impl Witness {
         transposed
     }
 
-    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
-    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -139,7 +136,6 @@ impl Witness {
 }
 
 impl KimchiVesta {
-    #[must_use]
     pub fn new(double_generic_gate_optimization: bool) -> Self {
         Self {
             next_variable: 0,

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -294,7 +294,7 @@ impl Backend for KimchiVesta {
 
         let zero = VestaField::zero();
 
-        let () = &self.add_generic_gate(
+        self.add_generic_gate(
             label.unwrap_or("hardcode a constant"),
             vec![Some(var)],
             vec![VestaField::one(), zero, zero, zero, value.neg()],

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -304,7 +304,6 @@ impl Backend for KimchiVesta {
         var
     }
 
-    #[allow(unused_variables)]
     fn finalize_circuit(
         &mut self,
         public_output: Option<Var<Self::Field, Self::Var>>,

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -106,7 +106,7 @@ impl Witness {
     pub fn to_kimchi_witness(&self) -> [Vec<VestaField>; NUM_REGISTERS] {
         let transposed = (0..NUM_REGISTERS)
             .map(|_| Vec::with_capacity(self.0.len()))
-            .collect::<Vec<_>>();
+            .collect_vec();
         let mut transposed: [_; NUM_REGISTERS] = transposed.try_into().unwrap();
         for row in &self.0 {
             for (col, field) in row.iter().enumerate() {
@@ -126,7 +126,7 @@ impl Witness {
 
     pub fn debug(&self) {
         for (row, values) in self.0.iter().enumerate() {
-            let values = values.iter().map(PrettyField).join(" | ");
+            let values = values.iter().map(PrettyField::pretty).join(" | ");
             println!("{row} - {values}");
         }
     }

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -126,10 +126,7 @@ impl Witness {
 
     pub fn debug(&self) {
         for (row, values) in self.0.iter().enumerate() {
-            let values = values
-                .iter()
-                .map(super::super::helpers::PrettyField::pretty)
-                .join(" | ");
+            let values = values.iter().map(PrettyField::pretty).join(" | ");
             println!("{row} - {values}");
         }
     }

--- a/src/backends/kimchi/prover.rs
+++ b/src/backends/kimchi/prover.rs
@@ -62,6 +62,7 @@ pub struct VerifierIndex {
 // Setup
 //
 
+#[allow(clippy::type_complexity)]
 impl KimchiVesta {
     pub fn compile_to_indexes(
         &self,
@@ -247,12 +248,12 @@ mod tests {
 
     #[test]
     fn test_public_output_constraint() -> miette::Result<()> {
-        let code = r#"fn main(pub public_input: Field, private_input: Field) -> Field {
+        let code = r"fn main(pub public_input: Field, private_input: Field) -> Field {
             let xx = private_input + public_input;
             assert_eq(xx, 2);
             let yy = xx + 6;
             return yy;
-        }"#;
+        }";
 
         let mut sources = Sources::new();
         let mut tast = TypeChecker::new();

--- a/src/backends/kimchi/prover.rs
+++ b/src/backends/kimchi/prover.rs
@@ -62,7 +62,6 @@ pub struct VerifierIndex {
 // Setup
 //
 
-#[allow(clippy::type_complexity)]
 impl KimchiVesta {
     pub fn compile_to_indexes(
         &self,

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, hash::Hash, str::FromStr};
+use std::{fmt::Debug, str::FromStr};
 
 use ark_ff::{Field, Zero};
 use num_bigint::BigUint;
@@ -9,7 +9,6 @@ use crate::{
     error::{Error, ErrorKind, Result},
     helpers::PrettyField,
     imports::FnHandle,
-    parser::FunctionDef,
     var::{Value, Var},
     witness::WitnessEnv,
 };
@@ -32,6 +31,8 @@ pub trait BackendField:
 /// It is intended to make it opaque to the frondend.
 pub trait BackendVar: Clone + Debug + PartialEq + Eq {}
 
+// TODO: Fix this by `Box`ing `KimchiVesta`.
+#[allow(clippy::large_enum_variant)]
 pub enum BackendKind {
     KimchiVesta(KimchiVesta),
     R1csBls12_381(R1CS<R1csBls12381Field>),
@@ -39,14 +40,17 @@ pub enum BackendKind {
 }
 
 impl BackendKind {
+    #[must_use]
     pub fn new_kimchi_vesta(use_double_generic: bool) -> Self {
         Self::KimchiVesta(KimchiVesta::new(use_double_generic))
     }
 
+    #[must_use]
     pub fn new_r1cs_bls12_381() -> Self {
         Self::R1csBls12_381(R1CS::new())
     }
 
+    #[must_use]
     pub fn new_r1cs_bn254() -> Self {
         Self::R1csBn254(R1CS::new())
     }
@@ -57,8 +61,8 @@ pub trait Backend: Clone {
     /// The circuit field / scalar field that the circuit is written on.
     type Field: BackendField;
 
-    /// The CellVar type for the backend.
-    /// Different backend is allowed to have different CellVar types.
+    /// The `CellVar` type for the backend.
+    /// Different backend is allowed to have different `CellVar` types.
     type Var: BackendVar;
 
     /// The generated witness type for the backend. Each backend may define its own witness format to be generated.
@@ -122,7 +126,7 @@ pub trait Backend: Clone {
         span: Span,
     ) -> Self::Var;
 
-    /// Backends should implement this function to load and compute the value of a CellVar.
+    /// Backends should implement this function to load and compute the value of a `CellVar`.
     fn compute_var(
         &self,
         env: &mut WitnessEnv<Self::Field>,

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -31,8 +31,6 @@ pub trait BackendField:
 /// It is intended to make it opaque to the frondend.
 pub trait BackendVar: Clone + Debug + PartialEq + Eq {}
 
-// TODO: Fix this by `Box`ing `KimchiVesta`.
-#[allow(clippy::large_enum_variant)]
 pub enum BackendKind {
     KimchiVesta(KimchiVesta),
     R1csBls12_381(R1CS<R1csBls12381Field>),

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -40,17 +40,14 @@ pub enum BackendKind {
 }
 
 impl BackendKind {
-    #[must_use]
     pub fn new_kimchi_vesta(use_double_generic: bool) -> Self {
         Self::KimchiVesta(KimchiVesta::new(use_double_generic))
     }
 
-    #[must_use]
     pub fn new_r1cs_bls12_381() -> Self {
         Self::R1csBls12_381(R1CS::new())
     }
 
-    #[must_use]
     pub fn new_r1cs_bn254() -> Self {
         Self::R1csBn254(R1CS::new())
     }

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -222,7 +222,6 @@ impl<F> R1CS<F>
 where
     F: BackendField,
 {
-    #[must_use]
     pub fn new() -> Self {
         Self {
             constraints: Vec::new(),
@@ -236,7 +235,6 @@ where
     }
 
     /// Returns the number of constraints.
-    #[must_use]
     pub fn num_constraints(&self) -> usize {
         self.constraints.len()
     }

--- a/src/backends/r1cs/snarkjs.rs
+++ b/src/backends/r1cs/snarkjs.rs
@@ -71,9 +71,6 @@ where
     r1cs_backend: R1CS<F>,
 }
 
-// TODO: The impls in this file return a `noname::error::Result`, but writers return
-// std::io::Error. Remove this allowance once we properly handle errors.
-#[allow(unused_results)]
 impl<F> SnarkjsExporter<F>
 where
     F: BackendField,
@@ -235,7 +232,7 @@ impl WitnessWriter {
             file_type_bytes.len() == 4,
             "File type must be 4 characters long"
         );
-        writer.write_all(file_type_bytes);
+        writer.write_all(file_type_bytes)?;
 
         // Write the version as a 32-bit unsigned integer in little endian
         writer.write_all(&version.to_le_bytes())?;
@@ -308,6 +305,8 @@ impl WitnessWriter {
         // Start writing the second section
         self.start_write_section(2)?;
 
+        // Write the witness values to the file
+        // Each witness value occupies the same number of bytes as the prime field
         for value in witness {
             self.write_big_int(value.clone(), field_n_bytes)?;
         }

--- a/src/backends/r1cs/snarkjs.rs
+++ b/src/backends/r1cs/snarkjs.rs
@@ -75,7 +75,6 @@ impl<F> SnarkjsExporter<F>
 where
     F: BackendField,
 {
-    #[must_use]
     pub fn new(r1cs_backend: R1CS<F>) -> SnarkjsExporter<F> {
         SnarkjsExporter { r1cs_backend }
     }

--- a/src/circuit_writer/fn_env.rs
+++ b/src/circuit_writer/fn_env.rs
@@ -26,12 +26,10 @@ where
 }
 
 impl<F: BackendField, C: BackendVar> VarInfo<F, C> {
-    #[must_use]
     pub fn new(var: Var<F, C>, mutable: bool, typ: Option<TyKind>) -> Self {
         Self { var, mutable, typ }
     }
 
-    #[must_use]
     pub fn reassign(&self, var: Var<F, C>) -> Self {
         Self {
             var,
@@ -40,7 +38,6 @@ impl<F: BackendField, C: BackendVar> VarInfo<F, C> {
         }
     }
 
-    #[must_use]
     pub fn reassign_range(&self, var: Var<F, C>, start: usize, len: usize) -> Self {
         // sanity check
         assert_eq!(var.len(), len);
@@ -82,7 +79,6 @@ where
 
 impl<F: BackendField, C: BackendVar> FnEnv<F, C> {
     /// Creates a new `FnEnv`
-    #[must_use]
     pub fn new() -> Self {
         Self {
             current_scope: 0,
@@ -135,7 +131,6 @@ impl<F: BackendField, C: BackendVar> FnEnv<F, C> {
     /// Retrieves type information on a variable, given a name.
     /// If the variable is not in scope, return false.
     // TODO: return an error no?
-    #[must_use]
     pub fn get_local_var(&self, var_name: &str) -> VarInfo<F, C> {
         let (scope, var_info) = self
             .vars

--- a/src/circuit_writer/mod.rs
+++ b/src/circuit_writer/mod.rs
@@ -1,3 +1,7 @@
+// TODO: There is a bunch of places where there are unused vars.
+// Remove this lint allowance when fixed.
+#![allow(unused_variables)]
+
 use crate::{
     backends::Backend,
     constants::Span,
@@ -98,7 +102,7 @@ impl<B: Backend> CircuitWriter<B> {
         }
 
         //
-        fn_env.add_local_var(var_name, var_info)
+        fn_env.add_local_var(var_name, var_info);
     }
 
     pub fn get_local_var(
@@ -117,7 +121,7 @@ impl<B: Backend> CircuitWriter<B> {
         fn_env.get_local_var(var_name)
     }
 
-    /// Retrieves the [FnInfo] for the `main()` function.
+    /// Retrieves the [`FnInfo`] for the `main()` function.
     /// This function should only be called if we know there's a main function,
     /// if there's no main function it'll panic.
     pub fn main_info(&self) -> Result<&FnInfo<B>> {
@@ -215,7 +219,7 @@ impl<B: Backend> CircuitWriter<B> {
         Ok(CompiledCircuit::new(circuit_writer))
     }
 
-    /// A wrapper for the backend generate_witness
+    /// A wrapper for the backend `generate_witness`
     pub fn generate_witness(
         &self,
         witness_env: &mut WitnessEnv<B::Field>,
@@ -223,6 +227,7 @@ impl<B: Backend> CircuitWriter<B> {
         self.backend.generate_witness(witness_env)
     }
 
+    #[allow(clippy::type_complexity)]
     fn handle_arg(
         &mut self,
         arg: &FnArg,

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -55,7 +55,6 @@ pub struct Gate {
 }
 
 impl Gate {
-    #[must_use]
     pub fn to_kimchi_gate(&self, row: usize) -> kimchi::circuits::gate::CircuitGate<VestaField> {
         kimchi::circuits::gate::CircuitGate {
             typ: self.typ.into(),

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -3,7 +3,6 @@ use std::fmt::{self, Display, Formatter};
 use ark_ff::{One, Zero};
 use kimchi::circuits::wires::Wire;
 use num_bigint::BigUint;
-use num_traits::Num as _;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -568,9 +567,7 @@ impl<B: Backend> CircuitWriter<B> {
             }
 
             ExprKind::BigUInt(b) => {
-                let ff = B::Field::try_from(b.to_owned()).map_err(|_| {
-                    self.error(ErrorKind::CannotConvertToField(b.to_string()), expr.span)
-                })?;
+                let ff = B::Field::from(b.to_owned());
 
                 let res = VarOrRef::Var(Var::new_constant(ff, expr.span));
                 Ok(Some(res))

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -339,7 +339,6 @@ impl<B: Backend> CircuitWriter<B> {
                     vars.push(var_info);
                 }
 
-                //
                 match &fn_info.kind {
                     // assert() <-- for example
                     FnKind::BuiltIn(_sig, handle) => {

--- a/src/cli/cmd_new_and_init.rs
+++ b/src/cli/cmd_new_and_init.rs
@@ -1,16 +1,16 @@
 use camino::Utf8PathBuf as PathBuf;
 use miette::{IntoDiagnostic, Result, WrapErr};
 
-const MAIN_CONTENT: &str = r#"fn main(pub xx: Field, yy: Field) {
+const MAIN_CONTENT: &str = r"fn main(pub xx: Field, yy: Field) {
     let zz = yy + 1;
     assert_eq(zz, xx);
 }
-"#;
+";
 
-const LIB_CONTENT: &str = r#"fn add(xx: Field, yy: Field) -> Field {
+const LIB_CONTENT: &str = r"fn add(xx: Field, yy: Field) -> Field {
     return xx + yy;
 }
-"#;
+";
 
 #[derive(clap::Parser)]
 pub struct CmdNew {
@@ -143,13 +143,11 @@ fn get_git_user() -> String {
         .output()
         .expect("failed to execute git command");
 
-    if !output.status.success() {
-        panic!("failed to get git user name");
-    }
+    assert!(output.status.success(), "failed to get git user name");
 
     let output = String::from_utf8(output.stdout).expect("couldn't parse git output as utf8");
 
     let username = output.trim().to_owned();
 
-    username.replace(" ", "_").to_lowercase()
+    username.replace(' ', "_").to_lowercase()
 }

--- a/src/cli/cmd_prove_and_verify.rs
+++ b/src/cli/cmd_prove_and_verify.rs
@@ -62,7 +62,7 @@ pub fn cmd_prove(args: CmdProve) -> miette::Result<()> {
             "proof created at path `{proof_path}`. You can use `noname --verify` to verify it. Note that you will need to pass the same JSON-encoded public inputs as you did when creating the proof. (If you didn't use the `--public-inputs` flag, then you don't need to pass any public inputs.)",
         );
     } else {
-        println!("proof created at path `{proof_path}`. Since running the proof produced a  public output `{public:?}`, you will need to also pass the expected public output to the verifier (who can run `noname verify --public-output '{public:?}'`).", public=public_output);
+        println!("proof created at path `{proof_path}`. Since running the proof produced a  public output `{public_output:?}`, you will need to also pass the expected public output to the verifier (who can run `noname verify --public-output '{public_output:?}'`).");
     }
 
     //
@@ -93,13 +93,13 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (_sources, _prover_index, verifier_index) = build(&curr_dir, false, false)?;
+    let (_sources, _prover_index, _verifier_index) = build(&curr_dir, false, false)?;
 
     // parse inputs
-    let mut public_inputs = parse_inputs(&args.public_inputs).unwrap();
+    let _public_inputs = parse_inputs(&args.public_inputs).unwrap();
 
     if let Some(public_output) = &args.public_output {
-        let public_output = parse_inputs(public_output).unwrap();
+        let _public_output = parse_inputs(public_output).unwrap();
 
         // TODO: add it to the public input
         todo!();
@@ -114,7 +114,7 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         miette::bail!("proof does not exist at path `{proof_path}`. Perhaps pass the correct path via the `--proof-path` flag?");
     }
 
-    let proof = rmp_serde::from_read(std::fs::File::open(&proof_path).unwrap())
+    rmp_serde::from_read(std::fs::File::open(&proof_path).unwrap())
         .into_diagnostic()
         .wrap_err(format!(
             "could not deserialize the given proof at `{proof_path}`"
@@ -129,6 +129,4 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
             .wrap_err("Failed to verify proof")?;
     */
     //
-
-    Ok(())
 }

--- a/src/cli/manifest.rs
+++ b/src/cli/manifest.rs
@@ -19,7 +19,7 @@ pub struct Package {
 
 impl Manifest {
     pub(crate) fn dependencies(&self) -> Vec<String> {
-        self.package.dependencies.clone().unwrap_or(vec![])
+        self.package.dependencies.clone().unwrap_or_default()
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,5 +13,5 @@ pub use cmd_prove_and_verify::{cmd_prove, cmd_verify, CmdProve, CmdVerify};
 /// The directory under the user home directory containing all noname-related files.
 pub const NONAME_DIRECTORY: &str = ".noname";
 
-/// The directory under [NONAME_DIRECTORY] containing all package-related files.
+/// The directory under [`NONAME_DIRECTORY`] containing all package-related files.
 pub const PACKAGE_DIRECTORY: &str = "packages";

--- a/src/cli/packages.rs
+++ b/src/cli/packages.rs
@@ -203,7 +203,6 @@ pub fn get_dep(dep: &UserRepo) -> Result<Manifest> {
 }
 
 /// Returns the dependencies of a package (given it's manifest).
-#[must_use]
 pub fn get_deps_of_package(manifest: &Manifest) -> Vec<UserRepo> {
     manifest
         .dependencies()
@@ -268,7 +267,6 @@ pub fn download_from_github(dep: &UserRepo) -> Result<()> {
     Ok(())
 }
 
-#[must_use]
 pub fn is_lib(path: &PathBuf) -> bool {
     path.join("src").join("lib.no").exists()
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,8 +1,8 @@
 //! This module is a wrapper API around noname.
 //! It is important that user-facing features use the functions here,
 //! as they attach the correct filename and source code to errors.
-//! It does that by transforming our [Error] type into a [miette::Error] type for all functions here.
-//! (via the [IntoMiette] trait that we define here.)
+//! It does that by transforming our [Error] type into a [`miette::Error`] type for all functions here.
+//! (via the [`IntoMiette`] trait that we define here.)
 
 use std::collections::HashMap;
 
@@ -24,7 +24,14 @@ pub struct Sources {
     pub map: HashMap<usize, (String, String)>,
 }
 
+impl Default for Sources {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Sources {
+    #[must_use]
     pub fn new() -> Self {
         let mut map = HashMap::new();
         map.insert(
@@ -40,6 +47,7 @@ impl Sources {
         self.id
     }
 
+    #[must_use]
     pub fn get(&self, id: &usize) -> Option<&(String, String)> {
         self.map.get(id)
     }
@@ -66,7 +74,7 @@ impl<T> IntoMiette<T> for Result<T> {
                     .expect("couldn't find source")
                     .clone();
                 let report: miette::Report = err.into();
-                return Err(report.with_source_code(NamedSource::new(filename, source)));
+                Err(report.with_source_code(NamedSource::new(filename, source)))
             }
         }
     }
@@ -84,7 +92,7 @@ pub fn typecheck_next_file<B: Backend>(
         .into_miette(sources)
 }
 
-/// This should not be used directly. Check [get_tast] instead.
+/// This should not be used directly. Check [`get_tast`] instead.
 pub fn typecheck_next_file_inner<B: Backend>(
     typechecker: &mut TypeChecker<B>,
     this_module: Option<UserRepo>,
@@ -116,7 +124,7 @@ pub fn get_nast<B: Backend>(
     let code = &sources.map[&filename_id].1;
 
     // lexer
-    let tokens = Token::parse(filename_id, &code)?;
+    let tokens = Token::parse(filename_id, code)?;
     if std::env::var("NONAME_VERBOSE").is_ok() {
         println!("lexer succeeded");
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -31,7 +31,6 @@ impl Default for Sources {
 }
 
 impl Sources {
-    #[must_use]
     pub fn new() -> Self {
         let mut map = HashMap::new();
         map.insert(
@@ -47,7 +46,6 @@ impl Sources {
         self.id
     }
 
-    #[must_use]
     pub fn get(&self, id: &usize) -> Option<&(String, String)> {
         self.map.get(id)
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,6 +24,7 @@ impl From<Span> for miette::SourceSpan {
 }
 
 impl Span {
+    #[must_use]
     pub fn new(filename_id: usize, start: usize, len: usize) -> Self {
         Self {
             filename_id,
@@ -32,14 +33,17 @@ impl Span {
         }
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.start == 0
     }
 
+    #[must_use]
     pub fn end(&self) -> usize {
         self.start + self.len
     }
 
+    #[must_use]
     pub fn merge_with(self, other: Self) -> Self {
         assert_eq!(self.filename_id, other.filename_id);
         let real_len = other.end() - self.start;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,7 +24,6 @@ impl From<Span> for miette::SourceSpan {
 }
 
 impl Span {
-    #[must_use]
     pub fn new(filename_id: usize, start: usize, len: usize) -> Self {
         Self {
             filename_id,
@@ -33,17 +32,14 @@ impl Span {
         }
     }
 
-    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.start == 0
     }
 
-    #[must_use]
     pub fn end(&self) -> usize {
         self.start + self.len
     }
 
-    #[must_use]
     pub fn merge_with(self, other: Self) -> Self {
         assert_eq!(self.filename_id, other.filename_id);
         let real_len = other.end() - self.start;

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,8 @@ pub struct Error {
 }
 
 impl Error {
-    /// Creates a new [Error] from an [ErrorKind].
+    /// Creates a new [Error] from an [`ErrorKind`].
+    #[must_use]
     pub fn new(label: &'static str, kind: ErrorKind, span: Span) -> Self {
         Self { label, kind, span }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,6 @@ pub struct Error {
 
 impl Error {
     /// Creates a new [Error] from an [`ErrorKind`].
-    #[must_use]
     pub fn new(label: &'static str, kind: ErrorKind, span: Span) -> Self {
         Self { label, kind, span }
     }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -62,11 +62,11 @@ impl std::fmt::Debug for BuiltinModule {
 /// * `&[Var]`: take an unbounded list of variables, this is because built-ins can take any number of arguments, and different built-ins might take different types of arguments
 /// * `Span`: take a span to return user-friendly errors
 /// * `-> Result<Option<Var>>`: return a `Result` with an `Option` of a `Var`. This is because built-ins can return a variable, or they can return nothing. If they return nothing, then the `Option` will be `None`. If they return a variable, then the `Option` will be `Some(Var)`.
-pub type FnHandle<B: Backend> = fn(
+pub type FnHandle<B> = fn(
     &mut CircuitWriter<B>,
-    &[VarInfo<B::Field, B::Var>],
+    &[VarInfo<<B as Backend>::Field, <B as Backend>::Var>],
     Span,
-) -> Result<Option<Var<B::Field, B::Var>>>;
+) -> Result<Option<Var<<B as Backend>::Field, <B as Backend>::Var>>>;
 
 /// The different types of a noname function.
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -92,9 +92,7 @@ impl<B: Backend> CompiledCircuit<B> {
             }
 
             (TyKind::Array(el_typ, size), Value::Array(values)) => {
-                if values.len() != (*size as usize) {
-                    panic!("wrong size of array");
-                }
+                assert!(values.len() == (*size as usize), "wrong size of array");
                 let mut res = vec![];
                 for value in values {
                     let el = self.parse_single_input(value, el_typ)?;
@@ -119,9 +117,10 @@ impl<B: Backend> CompiledCircuit<B> {
                 let fields = &struct_info.fields;
 
                 // make sure that they're the same length
-                if fields.len() != map.len() {
-                    panic!("wrong number of fields in struct (TODO: better error)");
-                }
+                assert!(
+                    fields.len() == map.len(),
+                    "wrong number of fields in struct (TODO: better error)"
+                );
 
                 // parse each field
                 let mut res = vec![];
@@ -138,12 +137,10 @@ impl<B: Backend> CompiledCircuit<B> {
 
                 Ok(res)
             }
-            (expected, observed) => {
-                return Err(ParsingError::MismatchJsonArgument(
-                    expected.clone(),
-                    observed,
-                ));
-            }
+            (expected, observed) => Err(ParsingError::MismatchJsonArgument(
+                expected.clone(),
+                observed,
+            )),
         }
     }
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -22,7 +22,6 @@ pub struct LexerCtx {
 }
 
 impl LexerCtx {
-    #[must_use]
     pub fn new(filename_id: usize) -> Self {
         Self {
             offset: 0,
@@ -30,12 +29,10 @@ impl LexerCtx {
         }
     }
 
-    #[must_use]
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("lexer", kind, span)
     }
 
-    #[must_use]
     pub fn span(&self, start: usize, len: usize) -> Span {
         Span::new(self.filename_id, start, len)
     }
@@ -74,7 +71,6 @@ pub enum Keyword {
 }
 
 impl Keyword {
-    #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "use" => Some(Self::Use),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -22,6 +22,7 @@ pub struct LexerCtx {
 }
 
 impl LexerCtx {
+    #[must_use]
     pub fn new(filename_id: usize) -> Self {
         Self {
             offset: 0,
@@ -29,10 +30,12 @@ impl LexerCtx {
         }
     }
 
+    #[must_use]
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("lexer", kind, span)
     }
 
+    #[must_use]
     pub fn span(&self, start: usize, len: usize) -> Span {
         Span::new(self.filename_id, start, len)
     }
@@ -71,6 +74,7 @@ pub enum Keyword {
 }
 
 impl Keyword {
+    #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "use" => Some(Self::Use),
@@ -111,7 +115,7 @@ impl Display for Keyword {
             Self::Const => "const",
         };
 
-        write!(f, "{}", desc)
+        write!(f, "{desc}")
     }
 }
 
@@ -153,7 +157,12 @@ pub enum TokenKind {
 
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use TokenKind::*;
+        use TokenKind::{
+            Ampersand, BigInt, Colon, Comma, Comment, Dot, DoubleAmpersand, DoubleColon, DoubleDot,
+            DoubleEqual, DoublePipe, Equal, Exclamation, Greater, Hex, Identifier, Keyword,
+            LeftBracket, LeftCurlyBracket, LeftParen, Less, Minus, Pipe, Plus, Question,
+            RightArrow, RightBracket, RightCurlyBracket, RightParen, SemiColon, Slash, Star,
+        };
         let desc = match self {
             Keyword(_) => "keyword (use, let, etc.)",
             Identifier(_) => {
@@ -191,7 +200,7 @@ impl Display for TokenKind {
             //            TokenType::Literal => "`\"something\"",
         };
 
-        write!(f, "{}", desc)
+        write!(f, "{desc}")
     }
 }
 
@@ -444,22 +453,22 @@ impl Token {
 mod tests {
     use super::*;
 
-    const CODE: &str = r#"use crypto::poseidon;
+    const CODE: &str = r"use crypto::poseidon;
 
 fn main(public_input: [fel; 3], private_input: [fel; 3]) -> [fel; 8] {
     let digest = poseidon(private_input);
     assert(digest == public_input);
 }
-"#;
+";
 
     #[test]
     fn test_lexer() {
         match Token::parse(0, CODE) {
             Ok(root) => {
-                println!("{:#?}", root);
+                println!("{root:#?}");
             }
             Err(e) => {
-                println!("{:?}", e);
+                println!("{e:?}");
             }
         }
     }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -158,8 +158,8 @@ pub enum TokenKind {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use TokenKind::{
-            Ampersand, BigInt, Colon, Comma, Comment, Dot, DoubleAmpersand, DoubleColon, DoubleDot,
-            DoubleEqual, DoublePipe, Equal, Exclamation, Greater, Hex, Identifier, Keyword,
+            Ampersand, BigUInt, Colon, Comma, Comment, Dot, DoubleAmpersand, DoubleColon,
+            DoubleDot, DoubleEqual, DoublePipe, Equal, Exclamation, Greater, Identifier, Keyword,
             LeftBracket, LeftCurlyBracket, LeftParen, Less, Minus, Pipe, Plus, Question,
             RightArrow, RightBracket, RightCurlyBracket, RightParen, SemiColon, Slash, Star,
         };

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -1,4 +1,4 @@
-//! Since [std::iter::Peekable] in Rust advances the iterator,
+//! Since [`std::iter::Peekable`] in Rust advances the iterator,
 //! I can't use it for peeking tokens.
 //! I haven't found a better way than implementing a wrapper
 //! that allows me to peek...
@@ -18,6 +18,7 @@ pub struct Tokens {
 }
 
 impl Tokens {
+    #[must_use]
     pub fn new(tokens: Vec<Token>) -> Self {
         Self {
             peeked: None,
@@ -33,12 +34,12 @@ impl Tokens {
         } else {
             // otherwise get from iterator and store in peeked
             let token = self.inner.next();
-            self.peeked = token.clone();
+            self.peeked.clone_from(&token);
             token
         }
     }
 
-    /// Like next() except that it also stores the last seen token in the given context
+    /// Like `next()` except that it also stores the last seen token in the given context
     /// (useful for debugging)
     pub fn bump(&mut self, ctx: &mut ParserCtx) -> Option<Token> {
         if let Some(token) = self.peeked.take() {
@@ -47,18 +48,18 @@ impl Tokens {
         } else {
             let token = self.inner.next();
             if token.is_some() {
-                ctx.last_token = token.clone();
+                ctx.last_token.clone_from(&token);
             }
             token
         }
     }
-    /// Like [Self::bump] but errors with `err` pointing to the latest token
+    /// Like [`Self::bump`] but errors with `err` pointing to the latest token
     pub fn bump_err(&mut self, ctx: &mut ParserCtx, err: ErrorKind) -> Result<Token> {
         self.bump(ctx)
             .ok_or_else(|| ctx.error(err, ctx.last_span()))
     }
 
-    /// Like [Self::bump] but errors if the token is not `typ`
+    /// Like [`Self::bump`] but errors if the token is not `typ`
     pub fn bump_expected(&mut self, ctx: &mut ParserCtx, typ: TokenKind) -> Result<Token> {
         let token = self.bump_err(ctx, ErrorKind::MissingToken)?;
         if token.kind == typ {
@@ -74,7 +75,7 @@ impl Tokens {
             Some(Token {
                 kind: TokenKind::Identifier(value),
                 span,
-            }) => Ok(Ident { value: value, span }),
+            }) => Ok(Ident { value, span }),
             Some(token) => Err(ctx.error(kind, token.span)),
             None => Err(ctx.error(kind, ctx.last_span())),
         }

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -18,7 +18,6 @@ pub struct Tokens {
 }
 
 impl Tokens {
-    #[must_use]
     pub fn new(tokens: Vec<Token>) -> Self {
         Self {
             peeked: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub mod helpers {
             let bigint: num_bigint::BigUint = (*self).into();
             let inv: num_bigint::BigUint = self.neg().into(); // gettho way of splitting the field into positive and negative elements
             if inv < bigint {
-                format!("-{}", inv)
+                format!("-{inv}")
             } else {
                 bigint.to_string()
             }
@@ -62,6 +62,7 @@ pub mod helpers {
     impl PrettyField for R1csBls12381Field {}
     impl PrettyField for R1csBn254Field {}
 
+    #[must_use]
     pub fn poseidon(input: [VestaField; 2]) -> VestaField {
         let mut sponge: ArithmeticSponge<VestaField, PlonkSpongeConstantsKimchi> =
             ArithmeticSponge::new(fp_kimchi::static_params());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ pub mod helpers {
     impl PrettyField for R1csBls12381Field {}
     impl PrettyField for R1csBn254Field {}
 
-    #[must_use]
     pub fn poseidon(input: [VestaField; 2]) -> VestaField {
         let mut sponge: ArithmeticSponge<VestaField, PlonkSpongeConstantsKimchi> =
             ArithmeticSponge::new(fp_kimchi::static_params());

--- a/src/name_resolution/context.rs
+++ b/src/name_resolution/context.rs
@@ -32,8 +32,8 @@ impl NameResCtx {
         Error::new("name resolution", kind, span)
     }
 
-    /// Resolves a single [ModulePath].
-    /// `force` is set to `true` if it is expected that the [ModulePath] is set to [ModulePath::Local].
+    /// Resolves a single [`ModulePath`].
+    /// `force` is set to `true` if it is expected that the [`ModulePath`] is set to [`ModulePath::Local`].
     /// This is usually the case for things like struct or function definitions.
     pub(crate) fn resolve(&self, module: &mut ModulePath, local: bool) -> Result<()> {
         match module {

--- a/src/name_resolution/mod.rs
+++ b/src/name_resolution/mod.rs
@@ -86,7 +86,7 @@ mod tests {
 
     use super::*;
 
-    const CODE: &str = r#"
+    const CODE: &str = r"
     use user::repo;
 
     const some_cst = 0;
@@ -99,7 +99,7 @@ mod tests {
         let aa = Thing { bb: yy };
         return repo::thing(xx, aa);
     }
-"#;
+";
 
     #[test]
     fn test_name_res() {

--- a/src/negative_tests.rs
+++ b/src/negative_tests.rs
@@ -8,11 +8,11 @@ use crate::{
 #[test]
 fn test_return() {
     // no return expected
-    let code = r#"
+    let code = r"
     fn thing(xx: Field) {
         return xx;
     }
-    "#;
+    ";
 
     let mut tast = TypeChecker::<KimchiVesta>::new();
     let res = typecheck_next_file_inner(
@@ -30,11 +30,11 @@ fn test_return() {
 #[test]
 fn test_return_expected() {
     // return expected
-    let code = r#"
+    let code = r"
     fn thing(xx: Field) -> Field {
         let yy = xx + 1;
     }
-    "#;
+    ";
 
     let mut tast = TypeChecker::<KimchiVesta>::new();
     let res = typecheck_next_file_inner(
@@ -52,11 +52,11 @@ fn test_return_expected() {
 #[test]
 fn test_return_mismatch() {
     // return type mismatch
-    let code = r#"
+    let code = r"
         fn thing(xx: Field) -> Field {
             return true;
         }
-        "#;
+        ";
 
     let mut tast = TypeChecker::<KimchiVesta>::new();
     let res = typecheck_next_file_inner(

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -207,7 +207,7 @@ impl Expr {
             }
 
             // true or false
-            TokenKind::Keyword(Keyword::True) | TokenKind::Keyword(Keyword::False) => {
+            TokenKind::Keyword(Keyword::True | Keyword::False) => {
                 let is_true = matches!(token.kind, TokenKind::Keyword(Keyword::True));
 
                 Expr::new(ctx, ExprKind::Bool(is_true), span)
@@ -344,7 +344,7 @@ impl Expr {
         lhs.parse_rhs(ctx, tokens)
     }
 
-    /// an expression is sometimes unfinished when we parse it with [Self::parse],
+    /// an expression is sometimes unfinished when we parse it with [`Self::parse`],
     /// we use this function to see if the expression we just parsed (`self`) is actually part of a bigger expression
     fn parse_rhs(self, ctx: &mut ParserCtx, tokens: &mut Tokens) -> Result<Expr> {
         // we peek into what's next to see if there's an expression that uses

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,6 +62,7 @@ pub struct ParserCtx {
 }
 
 impl ParserCtx {
+    #[must_use]
     pub fn new(filename_id: usize, node_id: usize) -> Self {
         Self {
             node_id,
@@ -70,6 +71,7 @@ impl ParserCtx {
         }
     }
 
+    #[must_use]
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("parser", kind, span)
     }
@@ -81,12 +83,12 @@ impl ParserCtx {
     }
 
     // TODO: I think I don't need this, I should always be able to use the last token I read if I don't see anything, otherwise maybe just write -1 to say "EOF"
+    #[must_use]
     pub fn last_span(&self) -> Span {
         let span = self
             .last_token
             .as_ref()
-            .map(|token| token.span)
-            .unwrap_or(Span::new(self.filename_id, 0, 0));
+            .map_or(Span::new(self.filename_id, 0, 0), |token| token.span);
         Span::new(self.filename_id, span.end(), 0)
     }
 }
@@ -197,28 +199,28 @@ mod tests {
 
     #[test]
     fn fn_signature() {
-        let code = r#"main(pub public_input: [Fel; 3], private_input: [Fel; 3]) -> [Fel; 3] { return public_input; }"#;
+        let code = r"main(pub public_input: [Fel; 3], private_input: [Fel; 3]) -> [Fel; 3] { return public_input; }";
         let tokens = &mut Token::parse(0, code).unwrap();
         let ctx = &mut ParserCtx::default();
         let parsed = FunctionDef::parse(ctx, tokens).unwrap();
-        println!("{:?}", parsed);
+        println!("{parsed:?}");
     }
 
     #[test]
     fn statement_assign() {
-        let code = r#"let digest = poseidon(private_input);"#;
+        let code = r"let digest = poseidon(private_input);";
         let tokens = &mut Token::parse(0, code).unwrap();
         let ctx = &mut ParserCtx::default();
         let parsed = Stmt::parse(ctx, tokens).unwrap();
-        println!("{:?}", parsed);
+        println!("{parsed:?}");
     }
 
     #[test]
     fn statement_assert() {
-        let code = r#"assert(digest == public_input);"#;
+        let code = r"assert(digest == public_input);";
         let tokens = &mut Token::parse(0, code).unwrap();
         let ctx = &mut ParserCtx::default();
         let parsed = Stmt::parse(ctx, tokens).unwrap();
-        println!("{:?}", parsed);
+        println!("{parsed:?}");
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,7 +62,6 @@ pub struct ParserCtx {
 }
 
 impl ParserCtx {
-    #[must_use]
     pub fn new(filename_id: usize, node_id: usize) -> Self {
         Self {
             node_id,
@@ -71,7 +70,6 @@ impl ParserCtx {
         }
     }
 
-    #[must_use]
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("parser", kind, span)
     }
@@ -83,7 +81,6 @@ impl ParserCtx {
     }
 
     // TODO: I think I don't need this, I should always be able to use the last token I read if I don't see anything, otherwise maybe just write -1 to say "EOF"
-    #[must_use]
     pub fn last_span(&self) -> Span {
         let span = self
             .last_token

--- a/src/parser/structs.rs
+++ b/src/parser/structs.rs
@@ -115,9 +115,10 @@ impl CustomType {
     pub fn parse(ctx: &mut ParserCtx, tokens: &mut Tokens) -> Result<Self> {
         let ty_name = tokens.bump_ident(ctx, ErrorKind::InvalidType)?;
 
-        if !is_type(&ty_name.value) {
-            panic!("type name should start with uppercase letter (TODO: better error");
-        }
+        assert!(
+            is_type(&ty_name.value),
+            "type name should start with uppercase letter (TODO: better error"
+        );
 
         // make sure that this type is allowed
         if !matches!(

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -198,6 +198,7 @@ pub enum TyKind {
 }
 
 impl TyKind {
+    #[must_use]
     pub fn match_expected(&self, expected: &TyKind) -> bool {
         match (self, expected) {
             (TyKind::BigInt, TyKind::Field) => true,
@@ -216,6 +217,7 @@ impl TyKind {
         }
     }
 
+    #[must_use]
     pub fn same_as(&self, other: &TyKind) -> bool {
         match (self, other) {
             (TyKind::BigInt, TyKind::Field) | (TyKind::Field, TyKind::BigInt) => true,
@@ -252,17 +254,18 @@ impl Display for TyKind {
                     name = name,
                     module = module.value
                 ),
-                ModulePath::Local => write!(f, "a `{}` struct", name),
+                ModulePath::Local => write!(f, "a `{name}` struct"),
             },
             TyKind::Field => write!(f, "Field"),
             TyKind::BigInt => write!(f, "BigInt"),
-            TyKind::Array(ty, size) => write!(f, "[{}; {}]", ty, size),
+            TyKind::Array(ty, size) => write!(f, "[{ty}; {size}]"),
             TyKind::Bool => write!(f, "Bool"),
         }
     }
 }
 
 impl Ty {
+    #[must_use]
     pub fn reserved_types(module: ModulePath, name: Ident) -> TyKind {
         match name.value.as_ref() {
             "Field" | "Bool" if !matches!(module, ModulePath::Local) => {
@@ -405,6 +408,7 @@ pub struct Ident {
 }
 
 impl Ident {
+    #[must_use]
     pub fn new(value: String, span: Span) -> Self {
         Self { value, span }
     }
@@ -418,7 +422,7 @@ impl Ident {
             }),
 
             _ => Err(ctx.error(
-                ErrorKind::ExpectedToken(TokenKind::Identifier("".to_string())),
+                ErrorKind::ExpectedToken(TokenKind::Identifier(String::new())),
                 token.span,
             )),
         }
@@ -432,10 +436,12 @@ pub enum AttributeKind {
 }
 
 impl AttributeKind {
+    #[must_use]
     pub fn is_public(&self) -> bool {
         matches!(self, Self::Pub)
     }
 
+    #[must_use]
     pub fn is_constant(&self) -> bool {
         matches!(self, Self::Const)
     }
@@ -448,10 +454,12 @@ pub struct Attribute {
 }
 
 impl Attribute {
+    #[must_use]
     pub fn is_public(&self) -> bool {
         self.kind.is_public()
     }
 
+    #[must_use]
     pub fn is_constant(&self) -> bool {
         self.kind.is_constant()
     }
@@ -514,18 +522,14 @@ pub struct FnArg {
 }
 
 impl FnArg {
+    #[must_use]
     pub fn is_public(&self) -> bool {
-        self.attribute
-            .as_ref()
-            .map(|attr| attr.is_public())
-            .unwrap_or(false)
+        self.attribute.as_ref().is_some_and(Attribute::is_public)
     }
 
+    #[must_use]
     pub fn is_constant(&self) -> bool {
-        self.attribute
-            .as_ref()
-            .map(|attr| attr.is_constant())
-            .unwrap_or(false)
+        self.attribute.as_ref().is_some_and(Attribute::is_constant)
     }
 }
 
@@ -574,6 +578,7 @@ impl FuncOrMethod {
 }
 
 impl FunctionDef {
+    #[must_use]
     pub fn is_main(&self) -> bool {
         self.sig.name.value == "main"
     }
@@ -687,12 +692,10 @@ impl FunctionDef {
                 } else {
                     attr.span.merge_with(arg_typ.span)
                 }
+            } else if &arg_name.value == "self" {
+                arg_name.span
             } else {
-                if &arg_name.value == "self" {
-                    arg_name.span
-                } else {
-                    arg_name.span.merge_with(arg_typ.span)
-                }
+                arg_name.span.merge_with(arg_typ.span)
             };
 
             let arg = FnArg {
@@ -811,6 +814,7 @@ impl FunctionDef {
 }
 
 // TODO: enforce snake_case?
+#[must_use]
 pub fn is_valid_fn_name(name: &str) -> bool {
     if let Some(first_char) = name.chars().next() {
         // first character is not a number
@@ -825,6 +829,7 @@ pub fn is_valid_fn_name(name: &str) -> bool {
 }
 
 // TODO: enforce CamelCase?
+#[must_use]
 pub fn is_valid_fn_type(name: &str) -> bool {
     if let Some(first_char) = name.chars().next() {
         // first character is not a number or alpha
@@ -864,6 +869,7 @@ pub struct Range {
 }
 
 impl Range {
+    #[must_use]
     pub fn range(&self) -> std::ops::Range<u32> {
         self.start..self.end
     }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,9 +1,5 @@
 use educe::Educe;
-use std::{
-    fmt::Display,
-    hash::{Hash, Hasher},
-    str::FromStr,
-};
+use std::{fmt::Display, hash::Hash, str::FromStr};
 
 use ark_ff::{Field, Zero};
 use serde::{Deserialize, Serialize};

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -194,7 +194,6 @@ pub enum TyKind {
 }
 
 impl TyKind {
-    #[must_use]
     pub fn match_expected(&self, expected: &TyKind) -> bool {
         match (self, expected) {
             (TyKind::BigInt, TyKind::Field) => true,
@@ -213,7 +212,6 @@ impl TyKind {
         }
     }
 
-    #[must_use]
     pub fn same_as(&self, other: &TyKind) -> bool {
         match (self, other) {
             (TyKind::BigInt, TyKind::Field) | (TyKind::Field, TyKind::BigInt) => true,
@@ -261,7 +259,6 @@ impl Display for TyKind {
 }
 
 impl Ty {
-    #[must_use]
     pub fn reserved_types(module: ModulePath, name: Ident) -> TyKind {
         match name.value.as_ref() {
             "Field" | "Bool" if !matches!(module, ModulePath::Local) => {
@@ -404,7 +401,6 @@ pub struct Ident {
 }
 
 impl Ident {
-    #[must_use]
     pub fn new(value: String, span: Span) -> Self {
         Self { value, span }
     }
@@ -432,12 +428,10 @@ pub enum AttributeKind {
 }
 
 impl AttributeKind {
-    #[must_use]
     pub fn is_public(&self) -> bool {
         matches!(self, Self::Pub)
     }
 
-    #[must_use]
     pub fn is_constant(&self) -> bool {
         matches!(self, Self::Const)
     }
@@ -450,12 +444,10 @@ pub struct Attribute {
 }
 
 impl Attribute {
-    #[must_use]
     pub fn is_public(&self) -> bool {
         self.kind.is_public()
     }
 
-    #[must_use]
     pub fn is_constant(&self) -> bool {
         self.kind.is_constant()
     }
@@ -518,12 +510,10 @@ pub struct FnArg {
 }
 
 impl FnArg {
-    #[must_use]
     pub fn is_public(&self) -> bool {
         self.attribute.as_ref().is_some_and(Attribute::is_public)
     }
 
-    #[must_use]
     pub fn is_constant(&self) -> bool {
         self.attribute.as_ref().is_some_and(Attribute::is_constant)
     }
@@ -574,7 +564,6 @@ impl FuncOrMethod {
 }
 
 impl FunctionDef {
-    #[must_use]
     pub fn is_main(&self) -> bool {
         self.sig.name.value == "main"
     }
@@ -810,7 +799,6 @@ impl FunctionDef {
 }
 
 // TODO: enforce snake_case?
-#[must_use]
 pub fn is_valid_fn_name(name: &str) -> bool {
     if let Some(first_char) = name.chars().next() {
         // first character is not a number
@@ -825,7 +813,6 @@ pub fn is_valid_fn_name(name: &str) -> bool {
 }
 
 // TODO: enforce CamelCase?
-#[must_use]
 pub fn is_valid_fn_type(name: &str) -> bool {
     if let Some(first_char) = name.chars().next() {
         // first character is not a number or alpha
@@ -865,7 +852,6 @@ pub struct Range {
 }
 
 impl Range {
-    #[must_use]
     pub fn range(&self) -> std::ops::Range<u32> {
         self.start..self.end
     }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,5 +1,5 @@
 //! This adds a few utility functions for serializing and deserializing
-//! [arkworks](http://arkworks.rs/) types that implement [CanonicalSerialize] and [CanonicalDeserialize].
+//! [arkworks](http://arkworks.rs/) types that implement [`CanonicalSerialize`] and [`CanonicalDeserialize`].
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use serde_with::Bytes;
@@ -13,10 +13,10 @@ pub mod ser {
     //! Simply use the following attribute on your field:
     //! `#[serde(with = "o1_utils::serialization::ser") attribute"]`
 
-    use super::*;
+    use super::{Bytes, CanonicalDeserialize, CanonicalSerialize};
     use serde_with::{DeserializeAs, SerializeAs};
 
-    /// You can use this to serialize an arkworks type with serde and the "serialize_with" attribute.
+    /// You can use this to serialize an arkworks type with serde and the "`serialize_with`" attribute.
     /// See <https://serde.rs/field-attrs.html>
     pub fn serialize<S>(val: impl CanonicalSerialize, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -29,7 +29,7 @@ pub mod ser {
         Bytes::serialize_as(&bytes, serializer)
     }
 
-    /// You can use this to deserialize an arkworks type with serde and the "deserialize_with" attribute.
+    /// You can use this to deserialize an arkworks type with serde and the "`deserialize_with`" attribute.
     /// See <https://serde.rs/field-attrs.html>
     pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
     where
@@ -45,7 +45,7 @@ pub mod ser {
 // Serialization with [serde_with]
 //
 
-/// You can use [SerdeAs] with [serde_with] in order to serialize and deserialize types that implement [CanonicalSerialize] and [CanonicalDeserialize],
+/// You can use [`SerdeAs`] with [`serde_with`] in order to serialize and deserialize types that implement [`CanonicalSerialize`] and [`CanonicalDeserialize`],
 /// or containers of types that implement these traits (Vec, arrays, etc.)
 /// Simply add annotations like `#[serde_as(as = "o1_utils::serialization::SerdeAs")]`
 /// See <https://docs.rs/serde_with/1.10.0/serde_with/guide/serde_as/index.html#switching-from-serdes-with-to-serde_as>

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -10,6 +10,7 @@ const POSEIDON_FN: &str = "poseidon(input: [Field; 2]) -> [Field; 3]";
 
 pub const CRYPTO_SIGS: &[&str] = &[POSEIDON_FN];
 
+#[must_use]
 pub fn get_crypto_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
     let ctx = &mut ParserCtx::default();
     let mut tokens = Token::parse(0, name).unwrap();
@@ -27,6 +28,7 @@ pub fn get_crypto_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
 }
 
 /// a function returns crypto functions
+#[must_use]
 pub fn crypto_fns<B: Backend>() -> Vec<FnInfo<B>> {
     CRYPTO_SIGS
         .iter()

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -10,7 +10,6 @@ const POSEIDON_FN: &str = "poseidon(input: [Field; 2]) -> [Field; 3]";
 
 pub const CRYPTO_SIGS: &[&str] = &[POSEIDON_FN];
 
-#[must_use]
 pub fn get_crypto_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
     let ctx = &mut ParserCtx::default();
     let mut tokens = Token::parse(0, name).unwrap();
@@ -28,7 +27,6 @@ pub fn get_crypto_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
 }
 
 /// a function returns crypto functions
-#[must_use]
 pub fn crypto_fns<B: Backend>() -> Vec<FnInfo<B>> {
     CRYPTO_SIGS
         .iter()

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -46,6 +46,7 @@ pub static BUILTIN_FN_NAMES: Lazy<HashSet<String>> = Lazy::new(|| {
         .collect()
 });
 
+#[must_use]
 pub fn get_builtin_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
     let ctx = &mut ParserCtx::default();
     let mut tokens = Token::parse(0, name).unwrap();
@@ -64,6 +65,7 @@ pub fn get_builtin_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
 }
 
 /// a function returns builtin functions
+#[must_use]
 pub fn builtin_fns<B: Backend>() -> Vec<FnInfo<B>> {
     BUILTIN_SIGS
         .iter()
@@ -121,10 +123,10 @@ fn assert_eq<B: Backend>(
         // a const and a var
         (ConstOrCell::Const(cst), ConstOrCell::Cell(cvar))
         | (ConstOrCell::Cell(cvar), ConstOrCell::Const(cst)) => {
-            compiler.backend.assert_eq_const(cvar, *cst, span)
+            compiler.backend.assert_eq_const(cvar, *cst, span);
         }
         (ConstOrCell::Cell(lhs), ConstOrCell::Cell(rhs)) => {
-            compiler.backend.assert_eq_var(lhs, rhs, span)
+            compiler.backend.assert_eq_var(lhs, rhs, span);
         }
     }
 

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -46,7 +46,6 @@ pub static BUILTIN_FN_NAMES: Lazy<HashSet<String>> = Lazy::new(|| {
         .collect()
 });
 
-#[must_use]
 pub fn get_builtin_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
     let ctx = &mut ParserCtx::default();
     let mut tokens = Token::parse(0, name).unwrap();
@@ -65,7 +64,6 @@ pub fn get_builtin_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
 }
 
 /// a function returns builtin functions
-#[must_use]
 pub fn builtin_fns<B: Backend>() -> Vec<FnInfo<B>> {
     BUILTIN_SIGS
         .iter()

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,16 +1,18 @@
 //! A number of helper function to check the syntax of some types.
 
 /// Returns true if the given string is a number in decimal.
+#[must_use]
 pub fn is_numeric(s: &str) -> bool {
     s.chars().all(|c| c.is_ascii_digit())
 }
 
 /// Returns true if the given string is an hexadecimal string (0x...)
+#[must_use]
 pub fn is_hexadecimal(s: &str) -> bool {
     let mut s = s.chars();
     let s0 = s.next();
     let s1 = s.next();
-    if matches!((s0, s1), (Some('0'), Some('x') | Some('X'))) {
+    if matches!((s0, s1), (Some('0'), Some('x' | 'X'))) {
         s.all(|c| c.is_ascii_hexdigit())
     } else {
         false
@@ -18,6 +20,7 @@ pub fn is_hexadecimal(s: &str) -> bool {
 }
 
 /// Returns true if the given string is an identifier or type
+#[must_use]
 pub fn is_identifier_or_type(s: &str) -> bool {
     let mut chars = s.chars();
     let first_letter = chars.next().unwrap();
@@ -30,6 +33,7 @@ pub fn is_identifier_or_type(s: &str) -> bool {
 
 /// Returns true if the given string is an identifier
 /// (starts with a lowercase letter)
+#[must_use]
 pub fn is_identifier(s: &str) -> bool {
     let mut chars = s.chars();
     let first_letter = chars.next().unwrap();
@@ -42,12 +46,13 @@ pub fn is_identifier(s: &str) -> bool {
 
 /// Returns true if the given string is a type
 /// (first letter is an uppercase)
+#[must_use]
 pub fn is_type(s: &str) -> bool {
     let mut chars = s.chars();
     let first_char = chars.next().unwrap();
     // first char is an uppercase letter
     // rest are lowercase alphanumeric
-    first_char.is_alphabetic() && first_char.is_uppercase() && chars.all(|c| (c.is_alphanumeric()))
+    first_char.is_alphabetic() && first_char.is_uppercase() && chars.all(char::is_alphanumeric)
     // TODO: check camel case?
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,13 +1,11 @@
 //! A number of helper function to check the syntax of some types.
 
 /// Returns true if the given string is a number in decimal.
-#[must_use]
 pub fn is_numeric(s: &str) -> bool {
     s.chars().all(|c| c.is_ascii_digit())
 }
 
 /// Returns true if the given string is an hexadecimal string (0x...)
-#[must_use]
 pub fn is_hexadecimal(s: &str) -> bool {
     let mut s = s.chars();
     let s0 = s.next();
@@ -20,7 +18,6 @@ pub fn is_hexadecimal(s: &str) -> bool {
 }
 
 /// Returns true if the given string is an identifier or type
-#[must_use]
 pub fn is_identifier_or_type(s: &str) -> bool {
     let mut chars = s.chars();
     let first_letter = chars.next().unwrap();
@@ -33,7 +30,6 @@ pub fn is_identifier_or_type(s: &str) -> bool {
 
 /// Returns true if the given string is an identifier
 /// (starts with a lowercase letter)
-#[must_use]
 pub fn is_identifier(s: &str) -> bool {
     let mut chars = s.chars();
     let first_letter = chars.next().unwrap();
@@ -46,7 +42,6 @@ pub fn is_identifier(s: &str) -> bool {
 
 /// Returns true if the given string is a type
 /// (first letter is an uppercase)
-#[must_use]
 pub fn is_type(s: &str) -> bool {
     let mut chars = s.chars();
     let first_char = chars.next().unwrap();

--- a/src/tests/examples.rs
+++ b/src/tests/examples.rs
@@ -211,7 +211,7 @@ fn test_lc_return(#[case] backend: BackendKind) -> miette::Result<()> {
 fn test_poseidon(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": ["1", "1"]}"#;
     let private_input = [1.into(), 1.into()];
-    let digest = crate::helpers::poseidon(private_input.clone());
+    let digest = crate::helpers::poseidon(private_input);
     let digest_dec = digest.to_dec_string();
     assert_eq!(
         "3654913405619483358804575553468071097765421484960111776885779739261304758583",
@@ -242,7 +242,7 @@ fn test_bool(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_mutable(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"xx": "2", "yy": "3"}"#;
-    let public_inputs = r#"{}"#;
+    let public_inputs = r"{}";
 
     test_file("mutable", public_inputs, private_inputs, vec![], backend)?;
 
@@ -265,7 +265,7 @@ fn test_for_loop(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_array(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"public_input": ["1", "2"]}"#;
 
     test_file("array", public_inputs, private_inputs, vec![], backend)?;
@@ -277,7 +277,7 @@ fn test_array(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_equals(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": ["3", "3"]}"#;
 
     test_file("equals", public_inputs, private_inputs, vec![], backend)?;
@@ -289,7 +289,7 @@ fn test_equals(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_types(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": "1", "yy": "2"}"#;
 
     test_file("types", public_inputs, private_inputs, vec![], backend)?;
@@ -301,7 +301,7 @@ fn test_types(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_const(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"player": "1"}"#;
     let expected_public_output = vec!["2"];
 
@@ -320,7 +320,7 @@ fn test_const(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_functions(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"one": "1"}"#;
 
     test_file("functions", public_inputs, private_inputs, vec![], backend)?;
@@ -332,7 +332,7 @@ fn test_functions(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_methods(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": "1"}"#;
 
     test_file("methods", public_inputs, private_inputs, vec![], backend)?;
@@ -344,7 +344,7 @@ fn test_methods(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_types_array(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": "1", "yy": "4"}"#;
 
     test_file(
@@ -362,7 +362,7 @@ fn test_types_array(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_iterate(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"bedroom_holes": "2"}"#;
     let expected_public_output = vec!["4"];
 
@@ -381,7 +381,7 @@ fn test_iterate(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_assignment(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": "2"}"#;
 
     test_file("assignment", public_inputs, private_inputs, vec![], backend)?;
@@ -393,7 +393,7 @@ fn test_assignment(#[case] backend: BackendKind) -> miette::Result<()> {
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs(BackendKind::R1csBls12_381(R1CS::new()))]
 fn test_if_else(#[case] backend: BackendKind) -> miette::Result<()> {
-    let private_inputs = r#"{}"#;
+    let private_inputs = r"{}";
     let public_inputs = r#"{"xx": "1"}"#;
 
     test_file("if_else", public_inputs, private_inputs, vec![], backend)?;

--- a/src/tests/modules.rs
+++ b/src/tests/modules.rs
@@ -26,7 +26,7 @@ fn Lol.new() -> Lol {
 }
 ";
 
-const LIB: &str = r#"
+const LIB: &str = r"
 use mimoo::liblib;
 
 // test a library's type that links to its own type
@@ -60,9 +60,9 @@ fn new_liblib() -> liblib::Lol {
 fn test_liblib(ff: Field, lol: liblib::Lol) {
     lol.match(ff);
 }
-"#;
+";
 
-const MAIN: &str = r#"
+const MAIN: &str = r"
 use mimoo::lib;
 
 fn main(pub xx: Field, yy: Field) {
@@ -79,7 +79,7 @@ fn main(pub xx: Field, yy: Field) {
     let lol = lib::new_liblib();
     lib::test_liblib(1, lol);
 }
-"#;
+";
 
 #[test]
 fn test_simple_module() -> miette::Result<()> {

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -27,7 +27,6 @@ where
 }
 
 impl<B: Backend> FnInfo<B> {
-    #[must_use]
     pub fn sig(&self) -> &FnSig {
         match &self.kind {
             FnKind::BuiltIn(sig, _) => sig,

--- a/src/type_checker/fn_env.rs
+++ b/src/type_checker/fn_env.rs
@@ -8,7 +8,7 @@ use crate::{
     parser::types::TyKind,
 };
 
-/// Some type information on local variables that we want to track in the [TypedFnEnv] environment.
+/// Some type information on local variables that we want to track in the [`TypedFnEnv`] environment.
 #[derive(Debug, Clone)]
 pub struct TypeInfo {
     /// If the variable can be mutated or not.
@@ -29,6 +29,7 @@ pub struct TypeInfo {
 }
 
 impl TypeInfo {
+    #[must_use]
     pub fn new(typ: TyKind, span: Span) -> Self {
         Self {
             mutable: false,
@@ -39,6 +40,7 @@ impl TypeInfo {
         }
     }
 
+    #[must_use]
     pub fn new_mut(typ: TyKind, span: Span) -> Self {
         Self {
             mutable: true,
@@ -46,6 +48,7 @@ impl TypeInfo {
         }
     }
 
+    #[must_use]
     pub fn new_cst(typ: TyKind, span: Span) -> Self {
         Self {
             constant: true,
@@ -68,7 +71,8 @@ pub struct TypedFnEnv {
 }
 
 impl TypedFnEnv {
-    /// Creates a new TypeEnv
+    /// Creates a new `TypeEnv`
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -83,7 +87,7 @@ impl TypedFnEnv {
         self.current_scope.checked_sub(1).expect("scope bug");
 
         // disable variables as we exit the scope
-        for (_name, (scope, type_info)) in self.vars.iter_mut() {
+        for (scope, type_info) in self.vars.values_mut() {
             if *scope > self.current_scope {
                 type_info.disabled = true;
             }
@@ -91,6 +95,7 @@ impl TypedFnEnv {
     }
 
     /// Returns true if a scope is a prefix of our scope.
+    #[must_use]
     pub fn is_in_scope(&self, prefix_scope: usize) -> bool {
         self.current_scope >= prefix_scope
     }
@@ -111,10 +116,12 @@ impl TypedFnEnv {
         }
     }
 
+    #[must_use]
     pub fn get_type(&self, ident: &str) -> Option<&TyKind> {
         self.get_type_info(ident).map(|type_info| &type_info.typ)
     }
 
+    #[must_use]
     pub fn mutable(&self, ident: &str) -> Option<bool> {
         self.get_type_info(ident).map(|type_info| type_info.mutable)
     }
@@ -122,6 +129,7 @@ impl TypedFnEnv {
     /// Retrieves type information on a variable, given a name.
     /// If the variable is not in scope, return false.
     // TODO: return an error no?
+    #[must_use]
     pub fn get_type_info(&self, ident: &str) -> Option<&TypeInfo> {
         if let Some((scope, type_info)) = self.vars.get(ident) {
             if self.is_in_scope(*scope) && !type_info.disabled {

--- a/src/type_checker/fn_env.rs
+++ b/src/type_checker/fn_env.rs
@@ -29,7 +29,6 @@ pub struct TypeInfo {
 }
 
 impl TypeInfo {
-    #[must_use]
     pub fn new(typ: TyKind, span: Span) -> Self {
         Self {
             mutable: false,
@@ -40,7 +39,6 @@ impl TypeInfo {
         }
     }
 
-    #[must_use]
     pub fn new_mut(typ: TyKind, span: Span) -> Self {
         Self {
             mutable: true,
@@ -48,7 +46,6 @@ impl TypeInfo {
         }
     }
 
-    #[must_use]
     pub fn new_cst(typ: TyKind, span: Span) -> Self {
         Self {
             constant: true,
@@ -72,7 +69,6 @@ pub struct TypedFnEnv {
 
 impl TypedFnEnv {
     /// Creates a new `TypeEnv`
-    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -95,7 +91,6 @@ impl TypedFnEnv {
     }
 
     /// Returns true if a scope is a prefix of our scope.
-    #[must_use]
     pub fn is_in_scope(&self, prefix_scope: usize) -> bool {
         self.current_scope >= prefix_scope
     }
@@ -116,12 +111,10 @@ impl TypedFnEnv {
         }
     }
 
-    #[must_use]
     pub fn get_type(&self, ident: &str) -> Option<&TyKind> {
         self.get_type_info(ident).map(|type_info| &type_info.typ)
     }
 
-    #[must_use]
     pub fn mutable(&self, ident: &str) -> Option<bool> {
         self.get_type_info(ident).map(|type_info| type_info.mutable)
     }
@@ -129,7 +122,6 @@ impl TypedFnEnv {
     /// Retrieves type information on a variable, given a name.
     /// If the variable is not in scope, return false.
     // TODO: return an error no?
-    #[must_use]
     pub fn get_type_info(&self, ident: &str) -> Option<&TypeInfo> {
         if let Some((scope, type_info)) = self.vars.get(ident) {
             if self.is_in_scope(*scope) && !type_info.disabled {

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -45,12 +45,10 @@ pub struct FullyQualified {
 }
 
 impl FullyQualified {
-    #[must_use]
     pub fn local(name: String) -> Self {
         Self { module: None, name }
     }
 
-    #[must_use]
     // TODO: Pass in `String`, instead of `&str`, so we don't hide an
     // allocation within.
     pub fn new(module: &ModulePath, name: &str) -> Self {
@@ -144,7 +142,6 @@ impl<B: Backend> Default for TypeChecker<B> {
 
 impl<B: Backend> TypeChecker<B> {
     // TODO: we can probably lazy const this
-    #[must_use]
     pub fn new() -> Self {
         let mut type_checker = Self {
             functions: HashMap::new(),
@@ -183,7 +180,6 @@ impl<B: Backend> TypeChecker<B> {
         type_checker
     }
 
-    #[must_use]
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("type-checker", kind, span)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 
+#[must_use]
 pub fn noname_version() -> String {
     format!("@ noname.{}\n\n", env!("CARGO_PKG_VERSION"))
 }
@@ -19,7 +20,7 @@ pub fn display_source(
         res.push('\n');
 
         // display filename
-        writeln!(res, "│ FILE: {}", file).unwrap();
+        writeln!(res, "│ FILE: {file}").unwrap();
         writeln!(res, "│{s}", s = "─".repeat(80)).unwrap();
 
         // source
@@ -61,7 +62,7 @@ fn find_exact_line(source: &str, span: crate::constants::Span) -> (usize, usize,
 
 pub fn title(res: &mut String, s: &str) {
     writeln!(res, "╭{s}╮", s = "─".repeat(s.len())).unwrap();
-    writeln!(res, "│{s}│", s = s).unwrap();
+    writeln!(res, "│{s}│").unwrap();
     writeln!(res, "╰{s}╯", s = "─".repeat(s.len())).unwrap();
     writeln!(res).unwrap();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
 use std::fmt::Write;
 
-#[must_use]
 pub fn noname_version() -> String {
     format!("@ noname.{}\n\n", env!("CARGO_PKG_VERSION"))
 }

--- a/src/var.rs
+++ b/src/var.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 /// The signature of a hint function
-pub type HintFn<B: Backend> = dyn Fn(&B, &mut WitnessEnv<B::Field>) -> Result<B::Field>;
+pub type HintFn<B> =
+    dyn Fn(&B, &mut WitnessEnv<<B as Backend>::Field>) -> Result<<B as Backend>::Field>;
 
 /// A variable's actual value in the witness can be computed in different ways.
 #[derive(Clone, Serialize, Deserialize)]
@@ -120,6 +121,7 @@ where
 }
 
 impl<F: Field, C: BackendVar> Var<F, C> {
+    #[must_use]
     pub fn new(cvars: Vec<ConstOrCell<F, C>>, span: Span) -> Self {
         Self { cvars, span }
     }
@@ -147,19 +149,22 @@ impl<F: Field, C: BackendVar> Var<F, C> {
 
     pub fn new_constant_typ(cst_info: &ConstInfo<F>, span: Span) -> Self {
         let ConstInfo { value, typ: _ } = cst_info;
-        let cvars = value.into_iter().cloned().map(ConstOrCell::Const).collect();
+        let cvars = value.iter().copied().map(ConstOrCell::Const).collect();
 
         Self { cvars, span }
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.cvars.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.cvars.is_empty()
     }
 
+    #[must_use]
     pub fn get(&self, idx: usize) -> Option<&ConstOrCell<F, C>> {
         if idx < self.cvars.len() {
             Some(&self.cvars[idx])
@@ -168,6 +173,7 @@ impl<F: Field, C: BackendVar> Var<F, C> {
         }
     }
 
+    #[must_use]
     pub fn constant(&self) -> Option<F> {
         if self.cvars.len() == 1 {
             self.cvars[0].cst()
@@ -176,6 +182,7 @@ impl<F: Field, C: BackendVar> Var<F, C> {
         }
     }
 
+    #[must_use]
     pub fn range(&self, start: usize, len: usize) -> &[ConstOrCell<F, C>] {
         &self.cvars[start..(start + len)]
     }

--- a/src/var.rs
+++ b/src/var.rs
@@ -121,7 +121,6 @@ where
 }
 
 impl<F: Field, C: BackendVar> Var<F, C> {
-    #[must_use]
     pub fn new(cvars: Vec<ConstOrCell<F, C>>, span: Span) -> Self {
         Self { cvars, span }
     }
@@ -154,17 +153,14 @@ impl<F: Field, C: BackendVar> Var<F, C> {
         Self { cvars, span }
     }
 
-    #[must_use]
     pub fn len(&self) -> usize {
         self.cvars.len()
     }
 
-    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.cvars.is_empty()
     }
 
-    #[must_use]
     pub fn get(&self, idx: usize) -> Option<&ConstOrCell<F, C>> {
         if idx < self.cvars.len() {
             Some(&self.cvars[idx])
@@ -173,7 +169,6 @@ impl<F: Field, C: BackendVar> Var<F, C> {
         }
     }
 
-    #[must_use]
     pub fn constant(&self) -> Option<F> {
         if self.cvars.len() == 1 {
             self.cvars[0].cst()
@@ -182,7 +177,6 @@ impl<F: Field, C: BackendVar> Var<F, C> {
         }
     }
 
-    #[must_use]
     pub fn range(&self, start: usize, len: usize) -> &[ConstOrCell<F, C>] {
         &self.cvars[start..(start + len)]
     }

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -5,7 +5,7 @@ use itertools::chain;
 //use serde::{Deserialize, Serialize};
 
 use crate::{
-    backends::{Backend, BackendVar},
+    backends::Backend,
     circuit_writer::CircuitWriter,
     compiler::Sources,
     error::{Error, ErrorKind, Result},
@@ -28,6 +28,7 @@ impl<F: Field> WitnessEnv<F> {
         assert!(self.var_values.insert(name, val).is_none());
     }
 
+    #[must_use]
     pub fn get_external(&self, name: &str) -> Vec<F> {
         // TODO: return an error instead of crashing
         self.var_values.get(name).unwrap().clone()

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -28,7 +28,6 @@ impl<F: Field> WitnessEnv<F> {
         assert!(self.var_values.insert(name, val).is_none());
     }
 
-    #[must_use]
     pub fn get_external(&self, name: &str) -> Vec<F> {
         // TODO: return an error instead of crashing
         self.var_values.get(name).unwrap().clone()


### PR DESCRIPTION
There's a lot of changes - I'll briefly summarize what I did:

I ran, as much as possible, the following:

```rust
cargo fix --all --allow-dirty
cargo fmt
cargo clippy --fix --all --allow--dirty
```

Some parts, I had to manually fix, or was out of scope of the current PR, so I added lint allowances + TODOs instead. An example of such 'out of scope' fixes include the `unused_must_use`s in `r1cs/snarkjs.rs` - these would require additional work on error handling which should probably belong in its own PR. For these cases, I prefer lint allowances since they allow us to easily find the spots where we want to fix later on.

Note that some of the lint allowances seem sane, so I didn't add TODOs for those, but only for those I felt would improve code quality if removed.