### PR TITLE
feat(types): impl `PartialEq` and `Hash` for `Ident` instead of `ModulePath`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +646,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1126,6 +1158,7 @@ dependencies = [
  "clap",
  "constraint_writers",
  "dirs",
+ "educe",
  "ena",
  "itertools",
  "kimchi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ark-ff = "0.3.0"
 ark-bls12-381 = "0.3.0"                                                                                         # bls12-381 curve for r1cs backend
 ark-bn254 = "0.3.0"                                                                                             # bn128 curve for r1cs backend
 ark-serialize = "0.3.0"                                                                                         # serialization of arkworks types
+educe = { version = "0.6", default-features = false, features = ["Hash"] }
 ena = "0.14.0"                                                                                                  # union-find implementation for the wiring
 num-bigint = "0.4.3"                                                                                            # big int library
 camino = "1.1.1"                                                                                                # to replace Path and PathBuf
@@ -20,16 +21,16 @@ dirs = "4.0.0"                                                                  
 itertools = "0.10.3"                                                                                            # useful iter traits
 kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "a5d8883ddf649c22f38aaac122d368ecb9fa2230" } # ZKP - Dec 5th, 2023 revision
 #kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "b9589626f834f9dbf9d587e73fd8176171231e90" } # ZKP
-miette = { version = "5.0.0", features = ["fancy"] } # nice errors
-num-traits = "0.2.15"                                # useful traits on big ints
-once_cell = "1.15.0"                                 # for lazy statics
-regex = "1.6.0"                                      # for regexes
-rmp-serde = "1.1.1"                                  # for serialization
-serde_with = "2.0.1"                                 # for serializing arkworks types
-serde_json = "1.0.85"                                # to (de)serialize JSON
-serde = "1.0.144"                                    # to (de)serialize objects
-thiserror = "1.0.31"                                 # helpful error traits
-toml = "0.8.8"                                       # to parse manifest files
-constraint_writers = { git = "https://github.com/iden3/circom.git", tag = "v2.1.8"}                             # to generate r1cs file
-num-bigint-dig = "0.6.0"                             # to adapt for circom lib
-rstest = "0.19.0"                                    # for testing different backend cases
+miette = { version = "5.0.0", features = ["fancy"] }                                 # nice errors
+num-traits = "0.2.15"                                                                # useful traits on big ints
+once_cell = "1.15.0"                                                                 # for lazy statics
+regex = "1.6.0"                                                                      # for regexes
+rmp-serde = "1.1.1"                                                                  # for serialization
+serde_with = "2.0.1"                                                                 # for serializing arkworks types
+serde_json = "1.0.85"                                                                # to (de)serialize JSON
+serde = "1.0.144"                                                                    # to (de)serialize objects
+thiserror = "1.0.31"                                                                 # helpful error traits
+toml = "0.8.8"                                                                       # to parse manifest files
+constraint_writers = { git = "https://github.com/iden3/circom.git", tag = "v2.1.8" } # to generate r1cs file
+num-bigint-dig = "0.6.0"                                                             # to adapt for circom lib
+rstest = "0.19.0"                                                                    # for testing different backend cases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ark-ff = "0.3.0"
 ark-bls12-381 = "0.3.0"                                                                                         # bls12-381 curve for r1cs backend
 ark-bn254 = "0.3.0"                                                                                             # bn128 curve for r1cs backend
 ark-serialize = "0.3.0"                                                                                         # serialization of arkworks types
-educe = { version = "0.6", default-features = false, features = ["Hash"] }
+educe = { version = "0.6", default-features = false, features = ["Hash", "PartialEq"] }
 ena = "0.14.0"                                                                                                  # union-find implementation for the wiring
 num-bigint = "0.4.3"                                                                                            # big int library
 camino = "1.1.1"                                                                                                # to replace Path and PathBuf

--- a/book/book.toml
+++ b/book/book.toml
@@ -16,4 +16,4 @@ additional-css = ["./mdbook-admonish.css"]
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "3.0.2" # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.0.2"    # do not edit: managed by `mdbook-admonish install`

--- a/book/book.toml
+++ b/book/book.toml
@@ -16,4 +16,4 @@ additional-css = ["./mdbook-admonish.css"]
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "3.0.2"    # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.0.2" # do not edit: managed by `mdbook-admonish install`

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -156,7 +156,6 @@ pub struct Ty {
 }
 
 /// The module preceding structs, functions, or variables.
-// TODO: Hash should probably be implemented manually, right now two alias might have different span and so this will give different hashes
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub enum ModulePath {
     #[default]
@@ -393,7 +392,7 @@ impl FnSig {
 }
 
 /// Any kind of text that can represent a type, a variable, a function name, etc.
-#[derive(Debug, Default, Clone, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, Hash, Serialize, Deserialize)]
 pub struct Ident {
     pub value: String,
     pub span: Span,
@@ -402,13 +401,6 @@ pub struct Ident {
 impl PartialEq for Ident {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
-    }
-}
-
-impl Hash for Ident {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-        self.span.hash(state);
     }
 }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -394,17 +394,12 @@ impl FnSig {
 
 /// Any kind of text that can represent a type, a variable, a function name, etc.
 #[derive(Debug, Default, Clone, Eq, Serialize, Deserialize, Educe)]
-#[educe(Hash)]
+#[educe(Hash, PartialEq)]
 pub struct Ident {
     pub value: String,
     #[educe(Hash(ignore))]
+    #[educe(PartialEq(ignore))]
     pub span: Span,
-}
-
-impl PartialEq for Ident {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
 }
 
 impl Ident {

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,3 +1,4 @@
+use educe::Educe;
 use std::{
     fmt::Display,
     hash::{Hash, Hasher},
@@ -392,9 +393,11 @@ impl FnSig {
 }
 
 /// Any kind of text that can represent a type, a variable, a function name, etc.
-#[derive(Debug, Default, Clone, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, Serialize, Deserialize, Educe)]
+#[educe(Hash)]
 pub struct Ident {
     pub value: String,
+    #[educe(Hash(ignore))]
     pub span: Span,
 }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,4 +1,8 @@
-use std::{fmt::Display, str::FromStr};
+use std::{
+    fmt::Display,
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
 
 use ark_ff::Field;
 use serde::{Deserialize, Serialize};
@@ -153,7 +157,7 @@ pub struct Ty {
 
 /// The module preceding structs, functions, or variables.
 // TODO: Hash should probably be implemented manually, right now two alias might have different span and so this will give different hashes
-#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub enum ModulePath {
     #[default]
     /// This is a local type, not imported from another module.
@@ -165,18 +169,6 @@ pub enum ModulePath {
     /// This is a type imported from another module,
     /// fully-qualified (as `user::repo`) thanks to the name resolution pass of the compiler.
     Absolute(UserRepo),
-}
-
-// TODO: do we want to implement this on Ident instead?
-impl PartialEq for ModulePath {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (ModulePath::Alias(a), ModulePath::Alias(b)) => a.value == b.value,
-            (ModulePath::Local, ModulePath::Local) => true,
-            (ModulePath::Absolute(a), ModulePath::Absolute(b)) => a == b,
-            _ => false,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -401,10 +393,23 @@ impl FnSig {
 }
 
 /// Any kind of text that can represent a type, a variable, a function name, etc.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, Serialize, Deserialize)]
 pub struct Ident {
     pub value: String,
     pub span: Span,
+}
+
+impl PartialEq for Ident {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Hash for Ident {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+        self.span.hash(state);
+    }
 }
 
 impl Ident {


### PR DESCRIPTION
Extracted from #100 

This follows the original implementation. 2 `Ident`s should be equal if their values are equal, even if their `Span`s are different. This also includes manually implementing `Hash` to allow for this.