### PR TITLE
chore: fix all unused_variables lint

### DIFF
--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -306,7 +306,7 @@ impl Backend for KimchiVesta {
         &mut self,
         public_output: Option<Var<Self::Field, Self::Var>>,
         returned_cells: Option<Vec<KimchiCellVar>>,
-        main_span: Span,
+        _main_span: Span,
     ) -> Result<()> {
         // TODO: the current tests pass even this is commented out. Add a test case for this one.
         // important: there might still be a pending generic gate

--- a/src/backends/r1cs/builtin.rs
+++ b/src/backends/r1cs/builtin.rs
@@ -10,9 +10,9 @@ use super::{LinearCombination, R1CS};
 
 // todo: impl this
 pub fn poseidon<F>(
-    compiler: &mut CircuitWriter<R1CS<F>>,
-    vars: &[VarInfo<F, LinearCombination<F>>],
-    span: Span,
+    _compiler: &mut CircuitWriter<R1CS<F>>,
+    _vars: &[VarInfo<F, LinearCombination<F>>],
+    _span: Span,
 ) -> Result<Option<Var<F, LinearCombination<F>>>>
 where
     F: BackendField,

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -317,7 +317,7 @@ where
     fn add_constant(
         &mut self,
         //todo: do we need this?
-        label: Option<&'static str>,
+        _label: Option<&'static str>,
         value: F,
         span: Span,
     ) -> LinearCombination<F> {
@@ -334,7 +334,7 @@ where
         &mut self,
         public_output: Option<crate::var::Var<Self::Field, Self::Var>>,
         returned_cells: Option<Vec<LinearCombination<F>>>,
-        main_span: Span,
+        _main_span: Span,
     ) -> crate::error::Result<()> {
         // store the return value in the public input that was created for that
         if let Some(public_output) = public_output {

--- a/src/circuit_writer/mod.rs
+++ b/src/circuit_writer/mod.rs
@@ -147,7 +147,6 @@ impl<B: Backend> CircuitWriter<B> {
         let mut circuit_writer = CircuitWriter::new(typed, backend);
 
         // get main function
-        let qualified = FullyQualified::local("main".to_string());
         let main_fn_info = circuit_writer.main_info()?;
 
         let function = match &main_fn_info.kind {

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -553,8 +553,7 @@ impl<B: Backend> CircuitWriter<B> {
 
             ExprKind::Negated(b) => {
                 let var = self.compute_expr(fn_env, b)?.unwrap();
-
-                let var = var.value(self, fn_env);
+                let _var = var.value(self, fn_env);
 
                 todo!()
             }

--- a/src/cli/cmd_build_and_check.rs
+++ b/src/cli/cmd_build_and_check.rs
@@ -92,7 +92,7 @@ pub fn cmd_build(args: CmdBuild) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (sources, prover_index, verifier_index) = build(&curr_dir, args.asm, args.debug)?;
+    let (_, _, verifier_index) = build(&curr_dir, args.asm, args.debug)?;
 
     // create COMPILED_DIR
     let compiled_path = curr_dir.join(COMPILED_DIR);

--- a/src/cli/cmd_prove_and_verify.rs
+++ b/src/cli/cmd_prove_and_verify.rs
@@ -93,13 +93,13 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (_sources, _prover_index, verifier_index) = build(&curr_dir, false, false)?;
+    let (_sources, _prover_index, _verifier_index) = build(&curr_dir, false, false)?;
 
     // parse inputs
-    let mut public_inputs = parse_inputs(&args.public_inputs).unwrap();
+    let mut _public_inputs = parse_inputs(&args.public_inputs).unwrap();
 
     if let Some(public_output) = &args.public_output {
-        let public_output = parse_inputs(public_output).unwrap();
+        let _public_output = parse_inputs(public_output).unwrap();
 
         // TODO: add it to the public input
         todo!();
@@ -114,7 +114,7 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         miette::bail!("proof does not exist at path `{proof_path}`. Perhaps pass the correct path via the `--proof-path` flag?");
     }
 
-    let proof = rmp_serde::from_read(std::fs::File::open(&proof_path).unwrap())
+    let _proof = rmp_serde::from_read(std::fs::File::open(&proof_path).unwrap())
         .into_diagnostic()
         .wrap_err(format!(
             "could not deserialize the given proof at `{proof_path}`"

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -198,7 +198,7 @@ impl<B: Backend> TypeChecker<B> {
                     }
 
                     // `array[idx] = <rhs>`
-                    ExprKind::ArrayAccess { array, idx } => {
+                    ExprKind::ArrayAccess { array, .. } => {
                         // get variable behind array
                         let array_node = self
                             .compute_type(array, typed_fn_env)?
@@ -210,7 +210,7 @@ impl<B: Backend> TypeChecker<B> {
                     }
 
                     // `struct.field = <rhs>`
-                    ExprKind::FieldAccess { lhs, rhs } => {
+                    ExprKind::FieldAccess { lhs, .. } => {
                         // get variable behind lhs
                         let lhs_node = self
                             .compute_type(lhs, typed_fn_env)?


### PR DESCRIPTION
Closes #101 
Extracted from #100 

As the title says - this ended up being a mostly harmless change since most unused variables here seem to be either unused because of unimplemented features or unused due to trait requirements