### PR TITLE
r1cs is default backend, default example works

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main(pub public_input: Field, private_input: [Field; 2]) {
 You can compile it with the following command:
 
 ```console
-$ noname test --path examples/example.no --private-inputs '{"private_input": ["1", "1"]}' --public-inputs '{"public_input": "3654913405619483358804575553468071097765421484960111776885779739261304758583"}' --debug
+$ noname test --path examples/arithmetic.no --private-inputs '{"private_input": "2"}' --public-inputs '{"public_input": "2"}' --debug
 ```
 
 Which will print the assembly, as well as try to create and verify a proof to make sure everything works. The assembly should look like this:

--- a/src/cli/cmd_build_and_check.rs
+++ b/src/cli/cmd_build_and_check.rs
@@ -265,7 +265,8 @@ pub struct CmdTest {
         short,
         long,
         value_parser,
-        help = SUPPORTED_BACKENDS.as_str()
+        help = SUPPORTED_BACKENDS.as_str(),
+        default_value = "r1cs-bn254"
     )]
     backend: String,
 


### PR DESCRIPTION
the default example didn't work with R1CS. Also I made R1CS the default so that we don't have to pass `--backend` by default.