### PR TITLE
Function name in use check

### DIFF
--- a/examples/iterate.no
+++ b/examples/iterate.no
@@ -16,15 +16,15 @@ fn House.room(self, const idx: Field) -> Room {
 }
 
 fn House.windows(house: House) -> Field {
-    let mut windows = 0;
+    let mut windows_count = 0;
     // ideally: for room in house.rooms {
     for room_idx in 0..2 {
         let room = house.room(room_idx);
         // ideally: windows +=
-        windows = windows + room.windows();
+        windows_count = windows_count + room.windows();
     }
 
-    return windows;
+    return windows_count;
 }
 
 fn main(pub bedroom_holes: Field) -> Field {

--- a/src/error.rs
+++ b/src/error.rs
@@ -213,6 +213,9 @@ pub enum ErrorKind {
     #[error("function `{0}` not present in scope (did you misspell it?)")]
     UndefinedFunction(String),
 
+    #[error("function name `{0}` is already in use by a variable present in the scope")]
+    FunctionNameInUsebyVariable(String),
+
     #[error("module `{0}` not present in scope (are you sure you imported it?)")]
     UndefinedModule(String),
 

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -596,7 +596,7 @@ impl<B: Backend> TypeChecker<B> {
             StmtKind::Expr(expr) => {
                 // make sure the expression does not return any type
                 // (it's a statement expression, it should only work via side effect)
-
+                
                 let typ = self.compute_type(expr, typed_fn_env)?;
                 if typ.is_some() {
                     return Err(self.error(ErrorKind::UnusedReturnValue, expr.span));
@@ -623,6 +623,12 @@ impl<B: Backend> TypeChecker<B> {
         args: &[Expr],
         span: Span,
     ) -> Result<Option<TyKind>> {
+        // check if a function names is in use already by another variable
+        match typed_fn_env.get_type_info(&fn_sig.name.value){
+            Some(_) => return Err(self.error(ErrorKind::FunctionNameInUsebyVariable(fn_sig.name.value), fn_sig.name.span)),
+            None => (), 
+        };
+        
         // canonicalize the arguments depending on method call or not
         let expected: Vec<_> = if method_call {
             fn_sig

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -596,7 +596,7 @@ impl<B: Backend> TypeChecker<B> {
             StmtKind::Expr(expr) => {
                 // make sure the expression does not return any type
                 // (it's a statement expression, it should only work via side effect)
-                
+
                 let typ = self.compute_type(expr, typed_fn_env)?;
                 if typ.is_some() {
                     return Err(self.error(ErrorKind::UnusedReturnValue, expr.span));
@@ -624,11 +624,16 @@ impl<B: Backend> TypeChecker<B> {
         span: Span,
     ) -> Result<Option<TyKind>> {
         // check if a function names is in use already by another variable
-        match typed_fn_env.get_type_info(&fn_sig.name.value){
-            Some(_) => return Err(self.error(ErrorKind::FunctionNameInUsebyVariable(fn_sig.name.value), fn_sig.name.span)),
-            None => (), 
+        match typed_fn_env.get_type_info(&fn_sig.name.value) {
+            Some(_) => {
+                return Err(self.error(
+                    ErrorKind::FunctionNameInUsebyVariable(fn_sig.name.value),
+                    fn_sig.name.span,
+                ))
+            }
+            None => (),
         };
-        
+
         // canonicalize the arguments depending on method call or not
         let expected: Vec<_> = if method_call {
             fn_sig


### PR DESCRIPTION
Fix https://github.com/zksecurity/noname/issues/93

for the following example 
```
use std::crypto;

fn double(xxx: Field) -> Field {
    return xxx + xxx;
} 

fn main(pub public_input: Field, private_input: Field) {
    let double = private_input;
    assert_eq(double, double(private_input));
}

``` 
the compiler should return
```
Error:   × Looks like something went wrong in type-checker
   ╭─[../../examples/example.no:2:1]
 2 │ 
 3 │ fn double(xxx: Field) -> Field {
   ·       ─┬─
   ·          ╰── here
 4 │     return xxx + xxx;
   ╰────
  help: function name `double` is already in use by a variable present in the scope
```

I updated  the test after reflecting the new checks work by making the pipeline fail at https://github.com/zksecurity/noname/actions/runs/9528372535/job/26265972691?pr=125#step:6:324
