### PR TITLE
feat: support conversion to arkworks constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-relations"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "tracing",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,7 +625,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -649,7 +660,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1123,6 +1134,7 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
+ "ark-relations",
  "ark-serialize",
  "camino",
  "clap",
@@ -1919,6 +1931,22 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "turshi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "a programming language for writing zkapps"
 ark-ec = "0.3.0"                                                                                                # elliptic curve library
 ark-ff = "0.3.0"
 ark-bls12-381 = "0.3.0"                                                                                         # bls12-381 curve for r1cs backend
+ark-relations = "0.3.0" 
 ark-bn254 = "0.3.0"                                                                                             # bn128 curve for r1cs backend
 ark-serialize = "0.3.0"                                                                                         # serialization of arkworks types
 educe = { version = "0.6", default-features = false, features = ["Hash", "PartialEq", "PartialOrd"] }

--- a/src/backends/r1cs/arkworks.rs
+++ b/src/backends/r1cs/arkworks.rs
@@ -1,0 +1,164 @@
+use crate::backends::r1cs::LinearCombination as NoNameLinearCombination;
+use crate::backends::{
+    r1cs::{GeneratedWitness, R1CS},
+    BackendField,
+};
+use crate::witness::CompiledCircuit;
+use ark_relations::r1cs::{
+    ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, SynthesisError, Variable,
+};
+use num_bigint::BigUint;
+
+use crate::circuit_writer::CircuitWriter;
+use crate::compiler::{typecheck_next_file, Sources};
+use crate::type_checker::TypeChecker;
+
+pub struct NoNameCircuit<BF: BackendField> {
+    compiled_circuit: CompiledCircuit<R1CS<BF>>,
+    witness: GeneratedWitness<BF>,
+}
+
+impl<BF: BackendField> ConstraintSynthesizer<BF> for NoNameCircuit<BF> {
+    fn generate_constraints(self, cs: ConstraintSystemRef<BF>) -> Result<(), SynthesisError> {
+        let public_io_length = self.compiled_circuit.circuit.backend.public_inputs.len()
+            + self.compiled_circuit.circuit.backend.public_outputs.len();
+
+        // arkworks assigns by default the 1 constant
+        // assumes witness is: [1, public_outputs, public_inputs, private_inputs, aux]
+        let witness_size = self.witness.witness.len();
+        for idx in 1..witness_size {
+            let value: BigUint = Into::into(self.witness.witness[idx]);
+            let field_element = BF::from(value);
+            if idx <= public_io_length {
+                cs.new_input_variable(|| Ok(field_element))?;
+            } else {
+                cs.new_witness_variable(|| Ok(field_element))?;
+            }
+        }
+
+        let make_index = |index| {
+            if index <= public_io_length {
+                match index == 0 {
+                    true => Variable::One,
+                    false => Variable::Instance(index),
+                }
+            } else {
+                Variable::Witness(index - (public_io_length + 1))
+            }
+        };
+
+        let make_lc = |lc_data: NoNameLinearCombination<BF>| {
+            let mut lc = LinearCombination::<BF>::zero();
+            for (cellvar, coeff) in lc_data.terms.into_iter() {
+                let idx = make_index(cellvar.index);
+                let coeff = BF::from(Into::<BigUint>::into(coeff));
+                lc += (coeff, idx)
+            }
+
+            // add constant
+            let constant = BF::from(Into::<BigUint>::into(lc_data.constant));
+            lc += (constant, make_index(0));
+            lc
+        };
+
+        for constraint in self.compiled_circuit.circuit.backend.constraints {
+            cs.enforce_constraint(
+                make_lc(constraint.a),
+                make_lc(constraint.b),
+                make_lc(constraint.c),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+pub const SIMPLE_ADDITION: &str = "fn main(pub public_input: Field, private_input: Field) {
+    let xx = private_input + public_input;
+    let yy = private_input * public_input;
+    assert_eq(xx, yy);
+}
+";
+
+pub const WITH_PUBLIC_OUTPUT_ARRAY: &str =
+    "fn main(pub public_input: [Field; 2], private_input: [Field; 2]) -> [Field; 2]{
+    let xx = private_input[0] + public_input[0];
+    let yy = private_input[1] * public_input[1];
+    assert_eq(yy, xx);
+    return [xx, yy];
+}";
+
+pub fn compile_source_code<BF: BackendField>(
+    code: &str,
+) -> Result<CompiledCircuit<R1CS<BF>>, crate::error::Error> {
+    let mut sources = Sources::new();
+
+    // parse the transitive dependency
+    let mut tast = TypeChecker::<R1CS<BF>>::new();
+    let mut node_id = 0;
+    node_id = typecheck_next_file(
+        &mut tast,
+        None,
+        &mut sources,
+        "main.no".to_string(),
+        code.to_string(),
+        node_id,
+    )
+    .unwrap();
+    let r1cs = R1CS::<BF>::new();
+    // compile
+    CircuitWriter::generate_circuit(tast, r1cs)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{backends::r1cs::R1csBn254Field, inputs::parse_inputs};
+    use ark_bn254::Fr;
+    use ark_relations::r1cs::ConstraintSystem;
+
+    #[test]
+    fn test_arkworks_cs_is_satisfied() {
+        let compiled_circuit = compile_source_code::<R1csBn254Field>(SIMPLE_ADDITION).unwrap();
+        let inputs_public = r#"{"public_input": "2"}"#;
+        let inputs_private = r#"{"private_input": "2"}"#;
+
+        let json_public = parse_inputs(inputs_public).unwrap();
+        let json_private = parse_inputs(inputs_private).unwrap();
+        let generated_witness = compiled_circuit
+            .generate_witness(json_public, json_private)
+            .unwrap();
+
+        let noname_circuit = NoNameCircuit {
+            compiled_circuit,
+            witness: generated_witness,
+        };
+
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        noname_circuit.generate_constraints(cs.clone()).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+    }
+
+    #[test]
+    fn test_arkworks_cs_is_satisfied_array() {
+        let compiled_circuit =
+            compile_source_code::<R1csBn254Field>(WITH_PUBLIC_OUTPUT_ARRAY).unwrap();
+        let inputs_public = r#"{"public_input": ["2", "5"]}"#;
+        let inputs_private = r#"{"private_input": ["8", "2"]}"#;
+
+        let json_public = parse_inputs(inputs_public).unwrap();
+        let json_private = parse_inputs(inputs_private).unwrap();
+        let generated_witness = compiled_circuit
+            .generate_witness(json_public, json_private)
+            .unwrap();
+        let noname_circuit = NoNameCircuit {
+            compiled_circuit,
+            witness: generated_witness,
+        };
+
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        noname_circuit.generate_constraints(cs.clone()).unwrap();
+        assert!(cs.is_satisfied().unwrap());
+    }
+}

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -1,3 +1,4 @@
+pub mod arkworks;
 pub mod builtin;
 pub mod snarkjs;
 


### PR DESCRIPTION
This PR upstreams the [`ark-noname`](https://github.com/dmpierre/ark-noname) code,  but using arkworks `3.0`. Aims to close [135](https://github.com/zksecurity/noname/issues/135).