### PR TITLE
proper modules

### DIFF
--- a/examples/generic_builtin_bits.no
+++ b/examples/generic_builtin_bits.no
@@ -1,23 +1,22 @@
-use std::to_bits;
-use std::from_bits;
+use std::bits;
 
 // 010 = xx, where xx = 2
 fn main(pub xx: Field) {
     // var
-    let bits = to_bits(3, xx);
+    let bits = bits::to_bits(3, xx);
     assert(!bits[0]);
     assert(bits[1]);
     assert(!bits[2]);
 
-    let val = from_bits(bits);
+    let val = bits::from_bits(bits);
     assert_eq(val, xx);
 
     // constant
-    let cst_bits = to_bits(3, 2);
+    let cst_bits = bits::to_bits(3, 2);
     assert(!cst_bits[0]);
     assert(cst_bits[1]);
     assert(!cst_bits[2]);
 
-    let cst = from_bits(cst_bits);
+    let cst = bits::from_bits(cst_bits);
     assert_eq(cst, xx);
 }

--- a/src/name_resolution/expr.rs
+++ b/src/name_resolution/expr.rs
@@ -2,7 +2,7 @@ use crate::{
     cli::packages::UserRepo,
     error::Result,
     parser::{types::ModulePath, CustomType, Expr, ExprKind},
-    stdlib::{BUILTIN_FN_NAMES, QUALIFIED_BUILTINS},
+    stdlib::builtins::{BUILTIN_FN_NAMES, QUALIFIED_BUILTINS},
 };
 
 use super::context::NameResCtx;
@@ -21,7 +21,8 @@ impl NameResCtx {
                 fn_name,
                 args,
             } => {
-                if matches!(module, ModulePath::Local) && BUILTIN_FN_NAMES.contains(&fn_name.value)
+                if matches!(module, ModulePath::Local)
+                    && BUILTIN_FN_NAMES.contains(&fn_name.value.as_str())
                 {
                     // if it's a builtin, use `std::builtin`
                     *module = ModulePath::Absolute(UserRepo::new(QUALIFIED_BUILTINS));

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -15,7 +15,7 @@ use crate::{
     error::{Error, ErrorKind, Result},
     lexer::{Keyword, Token, TokenKind, Tokens},
     mast::ExprMonoInfo,
-    stdlib::BUILTIN_FN_NAMES,
+    stdlib::builtins::BUILTIN_FN_NAMES,
     syntax::{is_generic_parameter, is_type},
 };
 
@@ -1089,7 +1089,7 @@ impl FunctionDef {
         let sig = FnSig::parse(ctx, tokens)?;
 
         // make sure that it doesn't shadow a builtin
-        if BUILTIN_FN_NAMES.contains(&sig.name.value) {
+        if BUILTIN_FN_NAMES.contains(&sig.name.value.as_ref()) {
             return Err(ctx.error(
                 ErrorKind::ShadowingBuiltIn(sig.name.value.clone()),
                 sig.name.span,

--- a/src/stdlib/bits.rs
+++ b/src/stdlib/bits.rs
@@ -1,0 +1,172 @@
+use std::vec;
+
+use ark_ff::One;
+use kimchi::o1_utils::FieldHelpers;
+
+use crate::{
+    backends::Backend,
+    circuit_writer::{CircuitWriter, VarInfo},
+    constants::Span,
+    constraints::boolean,
+    error::Result,
+    imports::FnKind,
+    lexer::Token,
+    parser::{
+        types::{FnSig, GenericParameters},
+        ParserCtx,
+    },
+    type_checker::FnInfo,
+    var::{ConstOrCell, Value, Var},
+};
+
+use super::{FnInfoType, Module};
+
+const TO_BITS_FN: &str = "to_bits(const LEN: Field, val: Field) -> [Bool; LEN]";
+const FROM_BITS_FN: &str = "from_bits(bits: [Bool; LEN]) -> Field";
+
+pub struct BitsLib {}
+
+impl Module for BitsLib {
+    const MODULE: &'static str = "bits";
+
+    fn get_fns<B: Backend>() -> Vec<(&'static str, FnInfoType<B>)> {
+        vec![(TO_BITS_FN, to_bits), (FROM_BITS_FN, from_bits)]
+    }
+}
+
+fn to_bits<B: Backend>(
+    compiler: &mut CircuitWriter<B>,
+    generics: &GenericParameters,
+    vars: &[VarInfo<B::Field, B::Var>],
+    span: Span,
+) -> Result<Option<Var<B::Field, B::Var>>> {
+    // should be two input vars
+    assert_eq!(vars.len(), 2);
+
+    // but the better practice would be to retrieve the value from the generics
+    let bitlen = generics.get("LEN") as usize;
+
+    // num should be greater than 0
+    assert!(bitlen > 0);
+
+    let modulus_bits: usize = B::Field::modulus_biguint()
+        .bits()
+        .try_into()
+        .expect("modulus is too large");
+
+    assert!(bitlen <= (modulus_bits - 1));
+
+    // alternatively, it can be retrieved from the first var, but it is not recommended
+    // let num_var = &vars[0];
+
+    // second var is the value to convert
+    let var_info = &vars[1];
+    let var = &var_info.var;
+    assert_eq!(var.len(), 1);
+
+    let val = match &var[0] {
+        ConstOrCell::Cell(cvar) => cvar.clone(),
+        ConstOrCell::Const(cst) => {
+            // extract the first bitlen bits
+            let bits = cst
+                .to_bits()
+                .iter()
+                .take(bitlen)
+                .copied()
+                // convert to ConstOrVar
+                .map(|b| ConstOrCell::Const(B::Field::from(b)))
+                .collect::<Vec<_>>();
+
+            return Ok(Some(Var::new(bits, span)));
+        }
+    };
+
+    // convert value to bits
+    let mut bits = Vec::with_capacity(bitlen);
+    let mut e2 = B::Field::one();
+    let mut lc: Option<B::Var> = None;
+
+    for i in 0..bitlen {
+        let bit = compiler
+            .backend
+            .new_internal_var(Value::NthBit(val.clone(), i), span);
+
+        // constrain it to be either 0 or 1
+        // bits[i] * (bits[i] - 1 ) === 0;
+        boolean::check(compiler, &ConstOrCell::Cell(bit.clone()), span);
+
+        // lc += bits[i] * e2;
+        let weighted_bit = compiler.backend.mul_const(&bit, &e2, span);
+        lc = if i == 0 {
+            Some(weighted_bit)
+        } else {
+            Some(compiler.backend.add(&lc.unwrap(), &weighted_bit, span))
+        };
+
+        bits.push(bit.clone());
+        e2 = e2 + e2;
+    }
+
+    compiler.backend.assert_eq_var(&val, &lc.unwrap(), span);
+
+    let bits_cvars = bits.into_iter().map(ConstOrCell::Cell).collect();
+    Ok(Some(Var::new(bits_cvars, span)))
+}
+
+fn from_bits<B: Backend>(
+    compiler: &mut CircuitWriter<B>,
+    generics: &GenericParameters,
+    vars: &[VarInfo<B::Field, B::Var>],
+    span: Span,
+) -> Result<Option<Var<B::Field, B::Var>>> {
+    // only one input var
+    assert_eq!(vars.len(), 1);
+
+    let var_info = &vars[0];
+    let bitlen = generics.get("LEN") as usize;
+
+    let modulus_bits: usize = B::Field::modulus_biguint()
+        .bits()
+        .try_into()
+        .expect("modulus is too large");
+
+    assert!(bitlen <= (modulus_bits - 1));
+
+    let bits_vars: Vec<_> = var_info
+        .var
+        .cvars
+        .iter()
+        .map(|c| match c {
+            ConstOrCell::Cell(c) => c.clone(),
+            ConstOrCell::Const(cst) => {
+                // use a cell var to represent the const for now
+                // later we will refactor the backend handle ConstOrCell arguments, so we don't have deal with this everywhere
+                compiler
+                    .backend
+                    .add_constant(Some("converted constant"), *cst, span)
+            }
+        })
+        .collect();
+
+    // this might not be necessary since it should be checked in the type checker
+    assert_eq!(bitlen, bits_vars.len());
+
+    let mut e2 = B::Field::one();
+    let mut lc: Option<B::Var> = None;
+
+    // accumulate the contribution of each bit
+    for bit in bits_vars {
+        let weighted_bit = compiler.backend.mul_const(&bit, &e2, span);
+
+        lc = match lc {
+            None => Some(weighted_bit),
+            Some(v) => Some(compiler.backend.add(&v, &weighted_bit, span)),
+        };
+
+        e2 = e2 + e2;
+    }
+
+    let cvar = ConstOrCell::Cell(lc.unwrap());
+
+    Ok(Some(Var::new_cvar(cvar, span)))
+}

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -1,0 +1,123 @@
+//! Builtins are imported by default.
+
+use ark_ff::One;
+
+use crate::{
+    backends::Backend,
+    circuit_writer::{CircuitWriter, VarInfo},
+    constants::Span,
+    error::{Error, ErrorKind, Result},
+    parser::types::{GenericParameters, TyKind},
+    var::{ConstOrCell, Var},
+};
+
+use super::{FnInfoType, Module};
+
+pub const QUALIFIED_BUILTINS: &str = "std/builtins";
+pub const BUILTIN_FN_NAMES: [&str; 2] = ["assert", "assert_eq"];
+
+const ASSERT_FN: &str = "assert(condition: Bool)";
+const ASSERT_EQ_FN: &str = "assert_eq(lhs: Field, rhs: Field)";
+
+pub struct BuiltinsLib {}
+
+impl Module for BuiltinsLib {
+    const MODULE: &'static str = "builtins";
+
+    fn get_fns<B: Backend>() -> Vec<(&'static str, FnInfoType<B>)> {
+        vec![(ASSERT_FN, assert_fn), (ASSERT_EQ_FN, assert_eq_fn)]
+    }
+}
+
+/// Asserts that two vars are equal.
+fn assert_eq_fn<B: Backend>(
+    compiler: &mut CircuitWriter<B>,
+    _generics: &GenericParameters,
+    vars: &[VarInfo<B::Field, B::Var>],
+    span: Span,
+) -> Result<Option<Var<B::Field, B::Var>>> {
+    // we get two vars
+    assert_eq!(vars.len(), 2);
+    let lhs_info = &vars[0];
+    let rhs_info = &vars[1];
+
+    // they are both of type field
+    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
+        panic!(
+            "the lhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
+            lhs_info.typ
+        );
+    }
+
+    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
+        panic!(
+            "the rhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
+            rhs_info.typ
+        );
+    }
+
+    // retrieve the values
+    let lhs_var = &lhs_info.var;
+    assert_eq!(lhs_var.len(), 1);
+    let lhs_cvar = &lhs_var[0];
+
+    let rhs_var = &rhs_info.var;
+    assert_eq!(rhs_var.len(), 1);
+    let rhs_cvar = &rhs_var[0];
+
+    match (lhs_cvar, rhs_cvar) {
+        // two constants
+        (ConstOrCell::Const(a), ConstOrCell::Const(b)) => {
+            if a != b {
+                return Err(Error::new(
+                    "constraint-generation",
+                    ErrorKind::AssertionFailed,
+                    span,
+                ));
+            }
+        }
+
+        // a const and a var
+        (ConstOrCell::Const(cst), ConstOrCell::Cell(cvar))
+        | (ConstOrCell::Cell(cvar), ConstOrCell::Const(cst)) => {
+            compiler.backend.assert_eq_const(cvar, *cst, span)
+        }
+        (ConstOrCell::Cell(lhs), ConstOrCell::Cell(rhs)) => {
+            compiler.backend.assert_eq_var(lhs, rhs, span)
+        }
+    }
+
+    Ok(None)
+}
+
+/// Asserts that a condition is true.
+fn assert_fn<B: Backend>(
+    compiler: &mut CircuitWriter<B>,
+    _generics: &GenericParameters,
+    vars: &[VarInfo<B::Field, B::Var>],
+    span: Span,
+) -> Result<Option<Var<B::Field, B::Var>>> {
+    // we get a single var
+    assert_eq!(vars.len(), 1);
+
+    // of type bool
+    let var_info = &vars[0];
+    assert!(matches!(var_info.typ, Some(TyKind::Bool)));
+
+    // of only one field element
+    let var = &var_info.var;
+    assert_eq!(var.len(), 1);
+    let cond = &var[0];
+
+    match cond {
+        ConstOrCell::Const(cst) => {
+            assert!(cst.is_one());
+        }
+        ConstOrCell::Cell(cvar) => {
+            let one = B::Field::one();
+            compiler.backend.assert_eq_const(cvar, one, span);
+        }
+    }
+
+    Ok(None)
+}

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -6,30 +6,16 @@ use crate::parser::types::FnSig;
 use crate::parser::ParserCtx;
 use crate::type_checker::FnInfo;
 
+use super::{FnInfoType, Module};
+
 const POSEIDON_FN: &str = "poseidon(input: [Field; 2]) -> [Field; 3]";
 
-pub const CRYPTO_SIGS: &[&str] = &[POSEIDON_FN];
+pub struct CryptoLib {}
 
-pub fn get_crypto_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
-    let ctx = &mut ParserCtx::default();
-    let mut tokens = Token::parse(0, name).unwrap();
-    let sig = FnSig::parse(ctx, &mut tokens).unwrap();
+impl Module for CryptoLib {
+    const MODULE: &'static str = "crypto";
 
-    let fn_handle = match name {
-        POSEIDON_FN => B::poseidon(),
-        _ => return None,
-    };
-
-    Some(FnInfo {
-        kind: FnKind::BuiltIn(sig, fn_handle),
-        span: Span::default(),
-    })
-}
-
-/// a function returns crypto functions
-pub fn crypto_fns<B: Backend>() -> Vec<FnInfo<B>> {
-    CRYPTO_SIGS
-        .iter()
-        .map(|sig| get_crypto_fn(sig).unwrap())
-        .collect()
+    fn get_fns<B: Backend>() -> Vec<(&'static str, FnInfoType<B>)> {
+        vec![(POSEIDON_FN, B::poseidon())]
+    }
 }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,310 +1,80 @@
-use std::collections::HashSet;
-
-use ark_ff::{One, Zero};
-use kimchi::o1_utils::FieldHelpers;
-use once_cell::sync::Lazy;
-
 use crate::{
     backends::Backend,
     circuit_writer::{CircuitWriter, VarInfo},
     constants::Span,
-    constraints::boolean,
-    error::{Error, ErrorKind, Result},
+    error::Result,
     imports::FnKind,
     lexer::Token,
     parser::{
-        types::{FnSig, GenericParameters, TyKind},
+        types::{FnSig, GenericParameters},
         ParserCtx,
     },
     type_checker::FnInfo,
-    var::{ConstOrCell, Value, Var},
+    var::Var,
 };
 
+pub mod bits;
+pub mod builtins;
 pub mod crypto;
 
-//
-// Builtins or utils (imported by default)
-// TODO: give a name that's useful for the user,
-//       not something descriptive internally like "builtins"
+pub enum AllStdModules {
+    Builtins,
+    Crypto,
+    Bits,
+}
 
-pub const QUALIFIED_BUILTINS: &str = "std/builtins";
+impl AllStdModules {
+    pub fn all_std_modules() -> Vec<AllStdModules> {
+        vec![
+            AllStdModules::Builtins,
+            AllStdModules::Crypto,
+            AllStdModules::Bits,
+        ]
+    }
 
-const ASSERT_FN: &str = "assert(condition: Bool)";
-const ASSERT_EQ_FN: &str = "assert_eq(lhs: Field, rhs: Field)";
-const TO_BITS_FN: &str = "to_bits(const LEN: Field, val: Field) -> [Bool; LEN]";
-const FROM_BITS_FN: &str = "from_bits(bits: [Bool; LEN]) -> Field";
+    pub fn get_parsed_fns<B: Backend>(&self) -> Vec<FnInfo<B>> {
+        match self {
+            AllStdModules::Builtins => builtins::BuiltinsLib::get_parsed_fns(),
+            AllStdModules::Crypto => crypto::CryptoLib::get_parsed_fns(),
+            AllStdModules::Bits => bits::BitsLib::get_parsed_fns(),
+        }
+    }
 
-// todo: each addition of builtins require changing this and `get_builtin_fn`,
-// - can we encapsulate them in a single place?
-/// List of builtin function signatures.
-pub const BUILTIN_SIGS: &[&str] = &[ASSERT_FN, ASSERT_EQ_FN, TO_BITS_FN, FROM_BITS_FN];
+    pub fn get_name(&self) -> &'static str {
+        match self {
+            AllStdModules::Builtins => builtins::BuiltinsLib::MODULE,
+            AllStdModules::Crypto => crypto::CryptoLib::MODULE,
+            AllStdModules::Bits => bits::BitsLib::MODULE,
+        }
+    }
+}
 
-// Unique set of builtin function names, derived from function signatures.
-pub static BUILTIN_FN_NAMES: Lazy<HashSet<String>> = Lazy::new(|| {
-    BUILTIN_SIGS
-        .iter()
-        .map(|s| {
+type FnInfoType<B: Backend> = fn(
+    &mut CircuitWriter<B>,
+    &GenericParameters,
+    &[VarInfo<B::Field, B::Var>],
+    Span,
+) -> Result<Option<Var<B::Field, B::Var>>>;
+
+trait Module {
+    /// e.g. "crypto"
+    const MODULE: &'static str;
+
+    fn get_fns<B: Backend>() -> Vec<(&'static str, FnInfoType<B>)>;
+
+    fn get_parsed_fns<B: Backend>() -> Vec<FnInfo<B>> {
+        let fns = Self::get_fns();
+        let mut res = Vec::with_capacity(fns.len());
+        for (code, fn_handle) in fns {
             let ctx = &mut ParserCtx::default();
-            let mut tokens = Token::parse(0, s).unwrap();
+            // TODO: we should try to point to real noname files here (not 0)
+            let mut tokens = Token::parse(0, code).unwrap();
             let sig = FnSig::parse(ctx, &mut tokens).unwrap();
-            sig.name.value
-        })
-        .collect()
-});
-
-pub fn get_builtin_fn<B: Backend>(name: &str) -> Option<FnInfo<B>> {
-    let ctx = &mut ParserCtx::default();
-    let mut tokens = Token::parse(0, name).unwrap();
-    let sig = FnSig::parse(ctx, &mut tokens).unwrap();
-
-    let fn_handle = match name {
-        ASSERT_FN => assert,
-        ASSERT_EQ_FN => assert_eq,
-        TO_BITS_FN => to_bits,
-        FROM_BITS_FN => from_bits,
-        _ => return None,
-    };
-
-    Some(FnInfo {
-        kind: FnKind::BuiltIn(sig, fn_handle),
-        span: Span::default(),
-    })
-}
-
-/// a function returns builtin functions
-pub fn builtin_fns<B: Backend>() -> Vec<FnInfo<B>> {
-    BUILTIN_SIGS
-        .iter()
-        .map(|sig| get_builtin_fn(sig).unwrap())
-        .collect()
-}
-
-/// Asserts that two vars are equal.
-fn assert_eq<B: Backend>(
-    compiler: &mut CircuitWriter<B>,
-    _generics: &GenericParameters,
-    vars: &[VarInfo<B::Field, B::Var>],
-    span: Span,
-) -> Result<Option<Var<B::Field, B::Var>>> {
-    // we get two vars
-    assert_eq!(vars.len(), 2);
-    let lhs_info = &vars[0];
-    let rhs_info = &vars[1];
-
-    // they are both of type field
-    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
-        panic!(
-            "the lhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
-            lhs_info.typ
-        );
-    }
-
-    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
-        panic!(
-            "the rhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
-            rhs_info.typ
-        );
-    }
-
-    // retrieve the values
-    let lhs_var = &lhs_info.var;
-    assert_eq!(lhs_var.len(), 1);
-    let lhs_cvar = &lhs_var[0];
-
-    let rhs_var = &rhs_info.var;
-    assert_eq!(rhs_var.len(), 1);
-    let rhs_cvar = &rhs_var[0];
-
-    match (lhs_cvar, rhs_cvar) {
-        // two constants
-        (ConstOrCell::Const(a), ConstOrCell::Const(b)) => {
-            if a != b {
-                return Err(Error::new(
-                    "constraint-generation",
-                    ErrorKind::AssertionFailed,
-                    span,
-                ));
-            }
+            res.push(FnInfo {
+                kind: FnKind::BuiltIn(sig, fn_handle),
+                span: Span::default(),
+            });
         }
-
-        // a const and a var
-        (ConstOrCell::Const(cst), ConstOrCell::Cell(cvar))
-        | (ConstOrCell::Cell(cvar), ConstOrCell::Const(cst)) => {
-            compiler.backend.assert_eq_const(cvar, *cst, span)
-        }
-        (ConstOrCell::Cell(lhs), ConstOrCell::Cell(rhs)) => {
-            compiler.backend.assert_eq_var(lhs, rhs, span)
-        }
+        res
     }
-
-    Ok(None)
-}
-
-/// Asserts that a condition is true.
-fn assert<B: Backend>(
-    compiler: &mut CircuitWriter<B>,
-    _generics: &GenericParameters,
-    vars: &[VarInfo<B::Field, B::Var>],
-    span: Span,
-) -> Result<Option<Var<B::Field, B::Var>>> {
-    // we get a single var
-    assert_eq!(vars.len(), 1);
-
-    // of type bool
-    let var_info = &vars[0];
-    assert!(matches!(var_info.typ, Some(TyKind::Bool)));
-
-    // of only one field element
-    let var = &var_info.var;
-    assert_eq!(var.len(), 1);
-    let cond = &var[0];
-
-    match cond {
-        ConstOrCell::Const(cst) => {
-            assert!(cst.is_one());
-        }
-        ConstOrCell::Cell(cvar) => {
-            let one = B::Field::one();
-            compiler.backend.assert_eq_const(cvar, one, span);
-        }
-    }
-
-    Ok(None)
-}
-
-fn to_bits<B: Backend>(
-    compiler: &mut CircuitWriter<B>,
-    generics: &GenericParameters,
-    vars: &[VarInfo<B::Field, B::Var>],
-    span: Span,
-) -> Result<Option<Var<B::Field, B::Var>>> {
-    // should be two input vars
-    assert_eq!(vars.len(), 2);
-
-    // but the better practice would be to retrieve the value from the generics
-    let bitlen = generics.get("LEN") as usize;
-
-    // num should be greater than 0
-    assert!(bitlen > 0);
-
-    let modulus_bits: usize = B::Field::modulus_biguint()
-        .bits()
-        .try_into()
-        .expect("modulus is too large");
-
-    assert!(bitlen <= (modulus_bits - 1));
-
-    // alternatively, it can be retrieved from the first var, but it is not recommended
-    // let num_var = &vars[0];
-
-    // second var is the value to convert
-    let var_info = &vars[1];
-    let var = &var_info.var;
-    assert_eq!(var.len(), 1);
-
-    let val = match &var[0] {
-        ConstOrCell::Cell(cvar) => cvar.clone(),
-        ConstOrCell::Const(cst) => {
-            // extract the first bitlen bits
-            let bits = cst
-                .to_bits()
-                .iter()
-                .take(bitlen)
-                .copied()
-                // convert to ConstOrVar
-                .map(|b| ConstOrCell::Const(B::Field::from(b)))
-                .collect::<Vec<_>>();
-
-            return Ok(Some(Var::new(bits, span)));
-        }
-    };
-
-    // convert value to bits
-    let mut bits = Vec::with_capacity(bitlen);
-    let mut e2 = B::Field::one();
-    let mut lc: Option<B::Var> = None;
-
-    for i in 0..bitlen {
-        let bit = compiler
-            .backend
-            .new_internal_var(Value::NthBit(val.clone(), i), span);
-
-        // constrain it to be either 0 or 1
-        // bits[i] * (bits[i] - 1 ) === 0;
-        boolean::check(compiler, &ConstOrCell::Cell(bit.clone()), span);
-
-        // lc += bits[i] * e2;
-        let weighted_bit = compiler.backend.mul_const(&bit, &e2, span);
-        lc = if i == 0 {
-            Some(weighted_bit)
-        } else {
-            Some(compiler.backend.add(&lc.unwrap(), &weighted_bit, span))
-        };
-
-        bits.push(bit.clone());
-        e2 = e2 + e2;
-    }
-
-    compiler.backend.assert_eq_var(&val, &lc.unwrap(), span);
-
-    let bits_cvars = bits.into_iter().map(ConstOrCell::Cell).collect();
-    Ok(Some(Var::new(bits_cvars, span)))
-}
-
-fn from_bits<B: Backend>(
-    compiler: &mut CircuitWriter<B>,
-    generics: &GenericParameters,
-    vars: &[VarInfo<B::Field, B::Var>],
-    span: Span,
-) -> Result<Option<Var<B::Field, B::Var>>> {
-    // only one input var
-    assert_eq!(vars.len(), 1);
-
-    let var_info = &vars[0];
-    let bitlen = generics.get("LEN") as usize;
-
-    let modulus_bits: usize = B::Field::modulus_biguint()
-        .bits()
-        .try_into()
-        .expect("modulus is too large");
-
-    assert!(bitlen <= (modulus_bits - 1));
-
-    let bits_vars: Vec<_> = var_info
-        .var
-        .cvars
-        .iter()
-        .map(|c| match c {
-            ConstOrCell::Cell(c) => c.clone(),
-            ConstOrCell::Const(cst) => {
-                // use a cell var to represent the const for now
-                // later we will refactor the backend handle ConstOrCell arguments, so we don't have deal with this everywhere
-                compiler
-                    .backend
-                    .add_constant(Some("converted constant"), *cst, span)
-            }
-        })
-        .collect();
-
-    // this might not be necessary since it should be checked in the type checker
-    assert_eq!(bitlen, bits_vars.len());
-
-    let mut e2 = B::Field::one();
-    let mut lc: Option<B::Var> = None;
-
-    // accumulate the contribution of each bit
-    for bit in bits_vars {
-        let weighted_bit = compiler.backend.mul_const(&bit, &e2, span);
-
-        lc = match lc {
-            None => Some(weighted_bit),
-            Some(v) => Some(compiler.backend.add(&v, &weighted_bit, span)),
-        };
-
-        e2 = e2 + e2;
-    }
-
-    let cvar = ConstOrCell::Cell(lc.unwrap());
-
-    Ok(Some(Var::new_cvar(cvar, span)))
 }

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         types::{FuncOrMethod, FunctionDef, ModulePath, RootKind, Ty, TyKind},
         CustomType, Expr, StructDef,
     },
-    stdlib::{builtin_fns, crypto::crypto_fns, QUALIFIED_BUILTINS},
+    stdlib::builtins::QUALIFIED_BUILTINS,
     syntax::is_generic_parameter,
 };
 
@@ -118,29 +118,19 @@ impl<B: Backend> TypeChecker<B> {
             node_types: HashMap::new(),
         };
 
-        // initialize it with the builtins
-        let builtin_module = ModulePath::Absolute(UserRepo::new(QUALIFIED_BUILTINS));
-        for fn_info in builtin_fns() {
-            let qualified = FullyQualified::new(&builtin_module, &fn_info.sig().name.value);
-            if type_checker
-                .functions
-                .insert(qualified, fn_info.clone())
-                .is_some()
-            {
-                panic!("type-checker bug: global imports conflict");
-            }
-        }
-
         // initialize it with the standard library
-        let crypto_module = ModulePath::Absolute(UserRepo::new("std/crypto"));
-        for fn_info in crypto_fns() {
-            let qualified = FullyQualified::new(&crypto_module, &fn_info.sig().name.value);
-            if type_checker
-                .functions
-                .insert(qualified, fn_info.clone())
-                .is_some()
-            {
-                panic!("type-checker bug: global imports conflict");
+        for module_impl in crate::stdlib::AllStdModules::all_std_modules() {
+            let module_path =
+                ModulePath::Absolute(UserRepo::new(&format!("std/{}", module_impl.get_name())));
+            for fn_info in module_impl.get_parsed_fns() {
+                let qualified = FullyQualified::new(&module_path, &fn_info.sig().name.value);
+                if type_checker
+                    .functions
+                    .insert(qualified, fn_info.clone())
+                    .is_some()
+                {
+                    panic!("type-checker bug: global imports conflict");
+                }
             }
         }
 


### PR DESCRIPTION
What I did in this PR:

* move bits and builtins stuff in their own rust modules
* introduce `Module` trait so that each module can just implement that

This is still a bit ugly (why enum lol) but it should be fine as it should be temporary. (because ideally modules should be declared as their own files, see https://github.com/zksecurity/noname/issues/157)

This will allow us to focus on implementing things instead of improving the modules. For example, if we want to mix native and builtins we can have builtins live in `std::bits_builtins` and the native code in `std::bits`.

