### PR TITLE
Improve type checker errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -281,11 +281,17 @@ pub enum ErrorKind {
     #[error("method call can only be applied on custom structs")]
     MethodCallOnNonCustomStruct,
 
+    #[error("field access can only be applied on custom structs")]
+    FieldAccessOnNonCustomStruct,
+
     #[error("array access can only be performed on arrays")]
     ArrayAccessOnNonArray,
 
     #[error("struct `{0}` does not exist (are you sure it is defined?)")]
     UndefinedStruct(String),
+
+    #[error("struct `{0}` does not have a method called `{1}`")]
+    UndefinedMethod(String, String),
 
     #[error("struct `{0}` does not have a field called `{1}`")]
     UndefinedField(String, String),
@@ -301,4 +307,19 @@ pub enum ErrorKind {
 
     #[error("invalid hexadecimal literal `${0}`")]
     InvalidHexLiteral(String),
+
+    #[error("if-else condition is expected to be a boolean, but has type `{0}`")]
+    IfElseInvalidConditionType(TyKind),
+
+    #[error("`if` branch must be a variable, a field access, or an array access. It can't be logic that creates constraints.")]
+    IfElseInvalidIfBranch(),
+
+    #[error("`else` branch must be a variable, a field access, or an array access. It can't be logic that creates constraints.")]
+    IfElseInvalidElseBranch(),
+
+    #[error("`if` branch and `else` branch must have matching types")]
+    IfElseMismatchingBranchesTypes(),
+
+    #[error("invalid range, the end value can't be smaller than the start value")]
+    InvalidRange,
 }


### PR DESCRIPTION
Improved the errors returned by the type checker: replaced most of the panics with errors which also display nicely the relevant code spans.

The code below sums up all the possible cases that now return nice errors

```rust
struct Thing {
    xx: Field,
    yy: Field,
}

fn main(pub xx: Field) {
    let mut thing = Thing { xx: xx, yy: xx + 1 };

    thing.xx = true;
    // help: type 'Field' and 'Bool' are not compatible

    let thing2 = true;
    let thing_int = 3;

    thing2.asd = false;
    // help: field access can only be applied on custom structs

    let thing3 = thing.zz;
    // help: struct `Thing` does not have a field called `zz`

    let thing4 = thing.not_existent();
    // help: struct `Thing` does not have a method called `not_existent`

    let yy = if 3 { thing2 } else { thing2 };
    // help: if-else condition is expected to be a boolean, but has type `BigInt`

    let yy = if true { 3 } else { thing2 };
    // help: `if` branch must be a variable, a field access, or an array access. It can't be logic that creates constraints.

    let yy = if true { thing2 } else { 2 };
    // help: `else` branch must be a variable, a field access, or an array access. It can't be logic that creates constraints.

    let yy = if true { thing_int } else { thing2 };
    // help: `if` branch and `else` branch must have matching types

    let mut sum = 0;
    for ii in 3..0 {
        sum = sum + 1;
    }
    //  help: invalid range, the end value can't be smaller than the start value

    assert_eq(xx, 3);
}
```

