### PR TITLE
Add constant field to TyKind::BigInt

### DIFF
--- a/src/backends/kimchi/builtin.rs
+++ b/src/backends/kimchi/builtin.rs
@@ -35,7 +35,7 @@ pub fn poseidon(
     // an array of length 2
     match &var_info.typ {
         Some(TyKind::Array(el_typ, 2)) => {
-            assert!(matches!(&**el_typ, TyKind::Field | TyKind::BigInt));
+            assert!(matches!(&**el_typ, TyKind::Field | TyKind::BigInt{..}));
         }
         _ => panic!("wrong type for input to poseidon"),
     };

--- a/src/backends/kimchi/builtin.rs
+++ b/src/backends/kimchi/builtin.rs
@@ -35,7 +35,7 @@ pub fn poseidon(
     // an array of length 2
     match &var_info.typ {
         Some(TyKind::Array(el_typ, 2)) => {
-            assert!(matches!(&**el_typ, TyKind::Field | TyKind::BigInt{..}));
+            assert!(matches!(&**el_typ, TyKind::Field | TyKind::BigInt { .. }));
         }
         _ => panic!("wrong type for input to poseidon"),
     };

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -273,7 +273,7 @@ impl<B: Backend> CircuitWriter<B> {
                     offset += len;
                 }
             }
-            TyKind::BigInt{..} => unreachable!(),
+            TyKind::BigInt { .. } => unreachable!(),
             TyKind::GenericSizedArray(_, _) => {
                 unreachable!("generic array should have been resolved")
             }

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -273,7 +273,7 @@ impl<B: Backend> CircuitWriter<B> {
                     offset += len;
                 }
             }
-            TyKind::BigInt => unreachable!(),
+            TyKind::BigInt{..} => unreachable!(),
             TyKind::GenericSizedArray(_, _) => {
                 unreachable!("generic array should have been resolved")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -257,6 +257,9 @@ pub enum ErrorKind {
     #[error("array indexes must be constants in circuits")]
     ExpectedConstant,
 
+    #[error("the function argument must be a constant")]
+    ExpectedConstantArg,
+
     #[error("kimchi setup: {0}")]
     KimchiSetup(#[from] kimchi::error::SetupError),
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -76,7 +76,7 @@ impl<B: Backend> CompiledCircuit<B> {
         use serde_json::Value;
 
         match (expected_input, input) {
-            (TyKind::BigInt, _) => unreachable!(),
+            (TyKind::BigInt{..}, _) => unreachable!(),
             (TyKind::Field, Value::String(ss)) => {
                 let cell_value =
                     B::Field::from_str(&ss).map_err(|_| ParsingError::InvalidField(ss))?;

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -76,7 +76,7 @@ impl<B: Backend> CompiledCircuit<B> {
         use serde_json::Value;
 
         match (expected_input, input) {
-            (TyKind::BigInt{..}, _) => unreachable!(),
+            (TyKind::BigInt { .. }, _) => unreachable!(),
             (TyKind::Field, Value::String(ss)) => {
                 let cell_value =
                     B::Field::from_str(&ss).map_err(|_| ParsingError::InvalidField(ss))?;

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -35,7 +35,7 @@ pub struct ExprMonoInfo {
 
 impl ExprMonoInfo {
     pub fn new(expr: Expr, typ: Option<TyKind>, value: Option<u32>) -> Self {
-        if value.is_some() && !matches!(typ, Some(TyKind::BigInt{ constant: true })) {
+        if value.is_some() && !matches!(typ, Some(TyKind::BigInt { constant: true })) {
             panic!("value can only be set for BigInt type");
         }
 
@@ -253,7 +253,7 @@ impl<B: Backend> Mast<B> {
 
                 sum
             }
-            TyKind::BigInt{..} => 1,
+            TyKind::BigInt { .. } => 1,
             TyKind::Array(typ, len) => (*len as usize) * self.size_of(typ),
             TyKind::GenericSizedArray(_, _) => {
                 unreachable!("generic arrays should have been resolved")
@@ -583,7 +583,7 @@ fn monomorphize_expr<B: Backend>(
             let cst: u32 = inner.try_into().expect("biguint too large");
             let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(inner.clone()));
 
-            ExprMonoInfo::new(mexpr, Some(TyKind::BigInt{ constant: true }), Some(cst))
+            ExprMonoInfo::new(mexpr, Some(TyKind::BigInt { constant: true }), Some(cst))
         }
 
         ExprKind::Bool(inner) => {
@@ -625,7 +625,7 @@ fn monomorphize_expr<B: Backend>(
                 let cst: u32 = bigint.clone().try_into().expect("biguint too large");
                 let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(bigint));
 
-                ExprMonoInfo::new(mexpr, Some(TyKind::BigInt{ constant: true}), Some(cst))
+                ExprMonoInfo::new(mexpr, Some(TyKind::BigInt { constant: true }), Some(cst))
             } else {
                 // otherwise it's a local variable
                 let mexpr = expr.to_mast(
@@ -879,7 +879,7 @@ pub fn monomorphize_stmt<B: Backend>(
                 &var.value,
                 // because we don't unroll the loop in the monomorphized AST
                 // no constant value even if it's a BigInt
-                &MTypeInfo::new(&TyKind::BigInt{ constant: true }, var.span, None),
+                &MTypeInfo::new(&TyKind::BigInt { constant: true }, var.span, None),
             )?;
 
             let start_mono = monomorphize_expr(ctx, &range.start, mono_fn_env)?;
@@ -982,7 +982,10 @@ pub fn instantiate_fn_call<B: Backend>(
     // store the values for generic parameters in the env
     for gen in &fn_sig.generics.names() {
         let val = fn_sig.generics.get(gen);
-        mono_fn_env.store_type(gen, &MTypeInfo::new(&TyKind::BigInt{ constant: true }, span, Some(val)))?;
+        mono_fn_env.store_type(
+            gen,
+            &MTypeInfo::new(&TyKind::BigInt { constant: true }, span, Some(val)),
+        )?;
     }
 
     // store the types of the arguments in the env

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -35,7 +35,7 @@ pub struct ExprMonoInfo {
 
 impl ExprMonoInfo {
     pub fn new(expr: Expr, typ: Option<TyKind>, value: Option<u32>) -> Self {
-        if value.is_some() && !matches!(typ, Some(TyKind::BigInt)) {
+        if value.is_some() && !matches!(typ, Some(TyKind::BigInt{ constant: true })) {
             panic!("value can only be set for BigInt type");
         }
 
@@ -253,7 +253,7 @@ impl<B: Backend> Mast<B> {
 
                 sum
             }
-            TyKind::BigInt => 1,
+            TyKind::BigInt{..} => 1,
             TyKind::Array(typ, len) => (*len as usize) * self.size_of(typ),
             TyKind::GenericSizedArray(_, _) => {
                 unreachable!("generic arrays should have been resolved")
@@ -583,7 +583,7 @@ fn monomorphize_expr<B: Backend>(
             let cst: u32 = inner.try_into().expect("biguint too large");
             let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(inner.clone()));
 
-            ExprMonoInfo::new(mexpr, Some(TyKind::BigInt), Some(cst))
+            ExprMonoInfo::new(mexpr, Some(TyKind::BigInt{ constant: true }), Some(cst))
         }
 
         ExprKind::Bool(inner) => {
@@ -625,7 +625,7 @@ fn monomorphize_expr<B: Backend>(
                 let cst: u32 = bigint.clone().try_into().expect("biguint too large");
                 let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(bigint));
 
-                ExprMonoInfo::new(mexpr, Some(TyKind::BigInt), Some(cst))
+                ExprMonoInfo::new(mexpr, Some(TyKind::BigInt{ constant: true}), Some(cst))
             } else {
                 // otherwise it's a local variable
                 let mexpr = expr.to_mast(
@@ -879,7 +879,7 @@ pub fn monomorphize_stmt<B: Backend>(
                 &var.value,
                 // because we don't unroll the loop in the monomorphized AST
                 // no constant value even if it's a BigInt
-                &MTypeInfo::new(&TyKind::BigInt, var.span, None),
+                &MTypeInfo::new(&TyKind::BigInt{ constant: true }, var.span, None),
             )?;
 
             let start_mono = monomorphize_expr(ctx, &range.start, mono_fn_env)?;
@@ -982,7 +982,7 @@ pub fn instantiate_fn_call<B: Backend>(
     // store the values for generic parameters in the env
     for gen in &fn_sig.generics.names() {
         let val = fn_sig.generics.get(gen);
-        mono_fn_env.store_type(gen, &MTypeInfo::new(&TyKind::BigInt, span, Some(val)))?;
+        mono_fn_env.store_type(gen, &MTypeInfo::new(&TyKind::BigInt{ constant: true }, span, Some(val)))?;
     }
 
     // store the types of the arguments in the env

--- a/src/name_resolution/context.rs
+++ b/src/name_resolution/context.rs
@@ -130,7 +130,7 @@ impl NameResCtx {
             TyKind::Custom { module, name: _ } => {
                 self.resolve(module, false)?;
             }
-            TyKind::BigInt => (),
+            TyKind::BigInt{..} => (),
             TyKind::Array(typ_kind, _) => self.resolve_typ_kind(typ_kind)?,
             TyKind::GenericSizedArray(typ_kind, _) => self.resolve_typ_kind(typ_kind)?,
             TyKind::Bool => (),

--- a/src/name_resolution/context.rs
+++ b/src/name_resolution/context.rs
@@ -130,7 +130,7 @@ impl NameResCtx {
             TyKind::Custom { module, name: _ } => {
                 self.resolve(module, false)?;
             }
-            TyKind::BigInt{..} => (),
+            TyKind::BigInt { .. } => (),
             TyKind::Array(typ_kind, _) => self.resolve_typ_kind(typ_kind)?,
             TyKind::GenericSizedArray(typ_kind, _) => self.resolve_typ_kind(typ_kind)?,
             TyKind::Bool => (),

--- a/src/negative_tests.rs
+++ b/src/negative_tests.rs
@@ -130,3 +130,85 @@ fn test_generic_array_for_loop() {
 
     assert!(matches!(res.unwrap_err().kind, ErrorKind::GenericInForLoop));
 }
+
+#[test]
+fn test_generic_missing_parameter_arg() {
+    let code = r#"
+        fn gen(const len: Field) -> [Field; LEN] {
+            return [0; LEN];
+        }
+        "#;
+
+    let mut tast = TypeChecker::<KimchiVesta>::new();
+    let res = typecheck_next_file_inner(
+        &mut tast,
+        None,
+        &mut Sources::new(),
+        "example.no".to_string(),
+        code.to_string(),
+        0,
+    );
+
+    assert!(matches!(
+        res.unwrap_err().kind,
+        ErrorKind::UndefinedVariable
+    ));
+}
+
+#[test]
+fn test_generic_ret_type_mismatched() {
+    let code = r#"
+        // mast phase should catch the type mismatch in the return type
+        fn gen(const LEN: Field) -> [Field; 2] {
+            return [0; LEN];
+        }
+
+        fn main(pub xx: Field) {
+            let ret = gen(3);
+        }
+        "#;
+
+    let mut tast = TypeChecker::<KimchiVesta>::new();
+    let _ = typecheck_next_file_inner(
+        &mut tast,
+        None,
+        &mut Sources::new(),
+        "example.no".to_string(),
+        code.to_string(),
+        0,
+    );
+    let res = crate::mast::monomorphize(tast).err();
+
+    assert!(matches!(
+        res.unwrap().kind,
+        ErrorKind::ReturnTypeMismatch(..)
+    ));
+}
+
+#[test]
+fn test_generic_disallow_var_arg() {
+    let code = r#"
+        fn gen(const LEN: Field) -> [Field; LEN] {
+            return [0; LEN];
+        }
+
+        fn main(pub xx: Field) {
+            let ret = gen(xx);
+        }
+        "#;
+
+    let mut tast = TypeChecker::<KimchiVesta>::new();
+    let res = typecheck_next_file_inner(
+        &mut tast,
+        None,
+        &mut Sources::new(),
+        "example.no".to_string(),
+        code.to_string(),
+        0,
+    );
+
+    assert!(matches!(
+        res.unwrap_err().kind,
+        ErrorKind::ExpectedConstantArg
+    ));
+}

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -141,7 +141,7 @@ pub fn parse_fn_call_args(ctx: &mut ParserCtx, tokens: &mut Tokens) -> Result<(V
 }
 
 pub fn is_numeric(typ: &TyKind) -> bool {
-    matches!(typ, TyKind::Field | TyKind::BigInt{..})
+    matches!(typ, TyKind::Field | TyKind::BigInt { .. })
 }
 
 //~
@@ -261,7 +261,7 @@ impl TyKind {
     /// A less strict checks when comparing with generic types.
     pub fn match_expected(&self, expected: &TyKind) -> bool {
         match (self, expected) {
-            (TyKind::BigInt{..}, TyKind::Field) | (TyKind::Field, TyKind::BigInt{..}) => true,
+            (TyKind::BigInt { .. }, TyKind::Field) | (TyKind::Field, TyKind::BigInt { .. }) => true,
             (TyKind::Array(lhs, lhs_size), TyKind::Array(rhs, rhs_size)) => {
                 lhs_size == rhs_size && lhs.match_expected(rhs)
             }
@@ -284,7 +284,7 @@ impl TyKind {
     /// An exact match check, assuming there is no generic type.
     pub fn same_as(&self, other: &TyKind) -> bool {
         match (self, other) {
-            (TyKind::BigInt{..}, TyKind::Field) | (TyKind::Field, TyKind::BigInt{..}) => true,
+            (TyKind::BigInt { .. }, TyKind::Field) | (TyKind::Field, TyKind::BigInt { .. }) => true,
             (TyKind::Array(lhs, lhs_size), TyKind::Array(rhs, rhs_size)) => {
                 lhs_size == rhs_size && lhs.same_as(rhs)
             }
@@ -307,7 +307,7 @@ impl TyKind {
 
         match self {
             TyKind::Field => (),
-            TyKind::BigInt{..} => (),
+            TyKind::BigInt { .. } => (),
             TyKind::Bool => (),
             TyKind::Custom { .. } => (),
             // e.g [[Field; N], 3]
@@ -345,7 +345,7 @@ impl Display for TyKind {
                 ModulePath::Local => write!(f, "a `{}` struct", name),
             },
             TyKind::Field => write!(f, "Field"),
-            TyKind::BigInt{..} => write!(f, "BigInt"),
+            TyKind::BigInt { .. } => write!(f, "BigInt"),
             TyKind::Array(ty, size) => write!(f, "[{}; {}]", ty, size),
             TyKind::Bool => write!(f, "Bool"),
             TyKind::GenericSizedArray(ty, size) => write!(f, "[{}; {}]", ty, size),

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -141,7 +141,7 @@ pub fn parse_fn_call_args(ctx: &mut ParserCtx, tokens: &mut Tokens) -> Result<(V
 }
 
 pub fn is_numeric(typ: &TyKind) -> bool {
-    matches!(typ, TyKind::Field | TyKind::BigInt)
+    matches!(typ, TyKind::Field | TyKind::BigInt{..})
 }
 
 //~
@@ -238,7 +238,7 @@ pub enum TyKind {
 
     /// This could be the same as Field, but we use this to also track the fact that it's a constant.
     // TODO: get rid of this type tho no?
-    BigInt,
+    BigInt { constant: bool },
 
     /// An array of a fixed size.
     Array(Box<TyKind>, u32),
@@ -261,7 +261,7 @@ impl TyKind {
     /// A less strict checks when comparing with generic types.
     pub fn match_expected(&self, expected: &TyKind) -> bool {
         match (self, expected) {
-            (TyKind::BigInt, TyKind::Field) | (TyKind::Field, TyKind::BigInt) => true,
+            (TyKind::BigInt{..}, TyKind::Field) | (TyKind::Field, TyKind::BigInt{..}) => true,
             (TyKind::Array(lhs, lhs_size), TyKind::Array(rhs, rhs_size)) => {
                 lhs_size == rhs_size && lhs.match_expected(rhs)
             }
@@ -284,7 +284,7 @@ impl TyKind {
     /// An exact match check, assuming there is no generic type.
     pub fn same_as(&self, other: &TyKind) -> bool {
         match (self, other) {
-            (TyKind::BigInt, TyKind::Field) | (TyKind::Field, TyKind::BigInt) => true,
+            (TyKind::BigInt{..}, TyKind::Field) | (TyKind::Field, TyKind::BigInt{..}) => true,
             (TyKind::Array(lhs, lhs_size), TyKind::Array(rhs, rhs_size)) => {
                 lhs_size == rhs_size && lhs.same_as(rhs)
             }
@@ -307,7 +307,7 @@ impl TyKind {
 
         match self {
             TyKind::Field => (),
-            TyKind::BigInt => (),
+            TyKind::BigInt{..} => (),
             TyKind::Bool => (),
             TyKind::Custom { .. } => (),
             // e.g [[Field; N], 3]
@@ -345,7 +345,7 @@ impl Display for TyKind {
                 ModulePath::Local => write!(f, "a `{}` struct", name),
             },
             TyKind::Field => write!(f, "Field"),
-            TyKind::BigInt => write!(f, "BigInt"),
+            TyKind::BigInt{..} => write!(f, "BigInt"),
             TyKind::Array(ty, size) => write!(f, "[{}; {}]", ty, size),
             TyKind::Bool => write!(f, "Bool"),
             TyKind::GenericSizedArray(ty, size) => write!(f, "[{}; {}]", ty, size),

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -42,14 +42,14 @@ fn assert_eq_fn<B: Backend>(
     let rhs_info = &vars[1];
 
     // they are both of type field
-    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt{..})) {
+    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt { .. })) {
         panic!(
             "the lhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
             lhs_info.typ
         );
     }
 
-    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt{..})) {
+    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt { .. })) {
         panic!(
             "the rhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
             rhs_info.typ

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -42,14 +42,14 @@ fn assert_eq_fn<B: Backend>(
     let rhs_info = &vars[1];
 
     // they are both of type field
-    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
+    if !matches!(lhs_info.typ, Some(TyKind::Field | TyKind::BigInt{..})) {
         panic!(
             "the lhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
             lhs_info.typ
         );
     }
 
-    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt)) {
+    if !matches!(rhs_info.typ, Some(TyKind::Field | TyKind::BigInt{..})) {
         panic!(
             "the rhs of assert_eq must be of type Field or BigInt. It was of type {:?}",
             rhs_info.typ


### PR DESCRIPTION
This a quick experimental change to allow to type check the const attribute in function.

This might be a good chance to complete this [todo note](https://github.com/zksecurity/noname/blob/3f08ecef82ef47922afaaeab37d63066d5c38dfd/src/parser/types.rs#L233).

By adding constant field to `TyKind::Field` instead, we might be able to remove the `TyKind::BigInt`, which is easy to confuse with `TyKind::Field`.