### PR TITLE
Automate Binary Releases for Noname

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Auto Release on Changelog Change
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check for changelog changes
+        id: changelog_check
+        run: |
+          # Get the latest tag
+          latest_tag=$(git describe --tags --abbrev=0)
+          # Get the commit hash of the latest tag
+          latest_commit=$(git rev-list -n 1 $latest_tag)
+          # Compare changelog file
+          if git diff --name-only $latest_commit HEAD | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=needs_release::true"
+          else
+            echo "No changes in CHANGELOG.md."
+            echo "::set-output name=needs_release::false"
+          fi
+
+      - name: Generate New Version Tag
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        id: generate_version_tag
+        run: |
+          # Get the latest version tag
+          latest_tag=$(git describe --tags --abbrev=0)
+          # Increment version number
+          major=$(echo $latest_tag | cut -d. -f1 | tr -d 'v')
+          minor=$(echo $latest_tag | cut -d. -f2)
+          patch=$(echo $latest_tag | cut -d. -f3)
+          new_patch=$((patch + 1))
+          new_version="v${major}.${minor}.${new_patch}"
+          echo "New version tag: $new_version"
+          echo "::set-output name=version_tag::$new_version"
+
+      - name: Build
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        run: cargo build --release
+
+      - name: Install GitHub CLI
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        run: sudo apt-get install gh
+
+      - name: Authenticate GitHub CLI
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        run: gh auth login --with-token < ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        run: |
+          gh release create ${{ steps.generate_version_tag.outputs.version_tag }} target/release/noname --title "Release ${{ steps.generate_version_tag.outputs.version_tag }}"
+          
+      - name: Upload assets
+        if: steps.changelog_check.outputs.needs_release == 'true'
+        run: |
+          gh release upload ${{ steps.generate_version_tag.outputs.version_tag }} target/release/noname --clobber


### PR DESCRIPTION
Automating Binary Releases for Noname by getting the latest version tag of Noname from CHANGELOG.md and building the binary release. Resolves issue #81 