### PR TITLE
Refactor for loops and iterators in the same statement structure

### DIFF
--- a/src/name_resolution/context.rs
+++ b/src/name_resolution/context.rs
@@ -7,7 +7,7 @@ use crate::{
     constants::Span,
     error::{Error, ErrorKind, Result},
     parser::{
-        types::{FnArg, FnSig, FuncOrMethod, ModulePath, Stmt, StmtKind, TyKind},
+        types::{FnArg, FnSig, ForLoopArgument, FuncOrMethod, ModulePath, Stmt, StmtKind, TyKind},
         ConstDef, CustomType, FunctionDef, StructDef, UsePath,
     },
 };
@@ -186,19 +186,15 @@ impl NameResCtx {
             StmtKind::Comment(_) => (),
             StmtKind::ForLoop {
                 var: _,
-                range: _,
+                argument,
                 body,
             } => {
-                for stmt in body {
-                    self.resolve_stmt(stmt)?;
+                // if the argument of the for loop is an iterator, resolve it
+                if let ForLoopArgument::Iterator(iterator) = argument {
+                    self.resolve_expr(iterator)?;
                 }
-            }
-            StmtKind::IteratorLoop {
-                var: _,
-                iterator,
-                body,
-            } => {
-                self.resolve_expr(iterator)?;
+
+                // resolve the body of the for loop
                 for stmt in body {
                     self.resolve_stmt(stmt)?;
                 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1260,17 +1260,10 @@ pub enum StmtKind {
     Return(Box<Expr>),
     Comment(String),
 
-    // `for var in 0..10 { <body> }`
+    // `for var in 0..10 { <body> }` or `for var in vec { <body> }`
     ForLoop {
         var: Ident,
-        range: Range,
-        body: Vec<Stmt>,
-    },
-
-    // `for item in vec { <body> }`
-    IteratorLoop {
-        var: Ident,
-        iterator: Box<Expr>,
+        argument: ForLoopArgument,
         body: Vec<Stmt>,
     },
 }
@@ -1411,22 +1404,14 @@ impl Stmt {
                     let statement = Stmt::parse(ctx, tokens)?;
                     body.push(statement);
                 }
-
-                //
-                match argument {
-                    ForLoopArgument::Range(range) => Ok(Stmt {
-                        kind: StmtKind::ForLoop { var, range, body },
-                        span,
-                    }),
-                    ForLoopArgument::Iterator(iterator) => Ok(Stmt {
-                        kind: StmtKind::IteratorLoop {
-                            var,
-                            iterator,
-                            body,
-                        },
-                        span,
-                    }),
-                }
+                Ok(Stmt {
+                    kind: StmtKind::ForLoop {
+                        var,
+                        argument,
+                        body,
+                    },
+                    span,
+                })
             }
 
             // if/else


### PR DESCRIPTION
This PR aims at addressing issue #176 by refactoring the `ForLoop` and `IteratorLoop` structures into a single structure

```rust
ForLoop {
    var: Ident,
    argument: ForLoopArgument,
    body: Vec<Stmt>,
}
```

using the `ForLoopArgument` enum as the argument type.

```rust
pub enum ForLoopArgument {
    Range(Range),
    Iterator(Box<Expr>),
}
```

Indeed this would have been much cleaner to implement iterators in this way from the beginning! I tried to merge as much as possible the code in the `ForLoop` and `IteratorLoop` cases throughout the compilation flow, but sometimes it ended up as a big `match` statement on the argument (e.g., in `circuit_writer.rs`).
Maybe in the future this could be refactored even further introducing a generic iterator trait in the codebase, having ranges and vectors as implementations.