### PR TITLE
feat: log builtin

### DIFF
--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -39,12 +39,38 @@ impl CellVar {
 
 impl<F: BackendField> BackendVar for LinearCombination<F> {}
 
+impl<F: BackendField> std::fmt::Debug for LinearCombination<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // format the linear combination as a single string
+        let mut lc = String::new();
+        for (i, (var, factor)) in self.terms.iter().enumerate() {
+            if i > 0 {
+                lc.push_str(" + ");
+            }
+
+            // format the factor
+            let factor = factor.pretty();
+            match factor.as_str() {
+                "1" => lc.push_str(&format!("v_{}", var.index)),
+                _ => lc.push_str(&format!("{} * v_{}", factor, var.index)),
+            }
+        }
+        // constant
+        if self.constant != F::zero() {
+            lc.push_str(&format!(" + {}", self.constant.pretty()));
+        }
+
+        // Write the formatted string to the formatter
+        write!(f, "{}", lc)
+    }
+}
+
 /// Linear combination of variables and constants.
 /// For example, the linear combination is represented as a * f_a + b * f_b + f_c
 /// f_a and f_b are the coefficients of a and b respectively.
 /// a and b are represented by CellVar.
 /// The constant f_c is represented by the constant field, will always multiply with the variable at index 0 which is always 1.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LinearCombination<F>
 where
     F: BackendField,


### PR DESCRIPTION
This is a logging feature to help debugging.

Usage:
```rust
let sum = var1 + var2;
log(sum); 
```

It should print something like:
```
---log span: Span { filename_id: 1, start: 147, len: 7 }---
typ: Some(Field { constant: false })
mutable: false
cvar: v_2 + v_1
```

Because it is a builtin function, so it only accesses to the info at compilation time.

It is quite common to check the values behind these variables. So we could record the cell var index at the backend, and print out the relevant witness values when generating witnesses.
