### PR TITLE
Fix: Allow struct fields to propagate constants

### DIFF
--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -9,7 +9,8 @@ use crate::{
     imports::FnKind,
     parser::{
         types::{
-            FnSig, ForLoopArgument, GenericParameters, Range, Stmt, StmtKind, Symbolic, Ty, TyKind,
+            FnSig, ForLoopArgument, GenericParameters, Ident, Range, Stmt, StmtKind, Symbolic, Ty,
+            TyKind,
         },
         CustomType, Expr, ExprKind, FunctionDef, Op2,
     },
@@ -29,19 +30,51 @@ pub struct ExprMonoInfo {
     /// The generic types shouldn't be presented in this field.
     pub typ: Option<TyKind>,
 
-    // todo: see if we can do constant folding on the expression nodes.
-    // - it is possible to remove this field, as the constant value can be extracted from folded expression node
-    /// Numeric value of the expression
-    /// applicable to BigInt type
-    pub constant: Option<u32>,
+    /// Propagated constant value
+    pub constant: Option<PropagatedConstant>,
+}
+
+#[derive(Debug, Clone)]
+pub enum PropagatedConstant {
+    Single(u32),
+    Array(Vec<PropagatedConstant>),
+    Custom(HashMap<Ident, PropagatedConstant>),
+}
+
+impl PropagatedConstant {
+    pub fn as_single(&self) -> u32 {
+        match self {
+            PropagatedConstant::Single(v) => *v,
+            _ => panic!("expected single value"),
+        }
+    }
+
+    pub fn as_array(&self) -> Vec<u32> {
+        match self {
+            PropagatedConstant::Array(v) => v.iter().map(|c| c.as_single()).collect(),
+            _ => panic!("expected array value"),
+        }
+    }
+
+    pub fn as_custom(&self) -> HashMap<Ident, u32> {
+        match self {
+            PropagatedConstant::Custom(v) => {
+                v.iter().map(|(k, c)| (k.clone(), c.as_single())).collect()
+            }
+            _ => panic!("expected custom value"),
+        }
+    }
+}
+
+/// impl From trait for single value
+impl From<u32> for PropagatedConstant {
+    fn from(v: u32) -> Self {
+        PropagatedConstant::Single(v)
+    }
 }
 
 impl ExprMonoInfo {
-    pub fn new(expr: Expr, typ: Option<TyKind>, value: Option<u32>) -> Self {
-        if value.is_some() && !matches!(typ, Some(TyKind::Field { constant: true })) {
-            panic!("value can only be set for BigInt type");
-        }
-
+    pub fn new(expr: Expr, typ: Option<TyKind>, value: Option<PropagatedConstant>) -> Self {
         Self {
             expr,
             typ,
@@ -68,18 +101,18 @@ pub struct MTypeInfo {
     pub typ: TyKind,
 
     /// Store constant value
-    pub value: Option<u32>,
+    pub constant: Option<PropagatedConstant>,
 
     /// The span of the variable declaration.
     pub span: Span,
 }
 
 impl MTypeInfo {
-    pub fn new(typ: &TyKind, span: Span, value: Option<u32>) -> Self {
+    pub fn new(typ: &TyKind, span: Span, value: Option<PropagatedConstant>) -> Self {
         Self {
             typ: typ.clone(),
             span,
-            value,
+            constant: value,
         }
     }
 }
@@ -216,11 +249,11 @@ impl FnSig {
                 }
                 // const NN: Field
                 _ => {
-                    let cst = observed_arg.constant;
+                    let cst = observed_arg.constant.clone();
                     if is_generic_parameter(sig_arg.name.value.as_str()) && cst.is_some() {
                         self.generics.assign(
                             &sig_arg.name.value,
-                            cst.unwrap(),
+                            cst.unwrap().as_single(),
                             observed_arg.expr.span,
                         )?;
                     }
@@ -269,6 +302,10 @@ where
     functions_instantiated: HashMap<FullyQualified, FullyQualified>,
     // new method name as the key, old method name as the value
     methods_instantiated: HashMap<(FullyQualified, String), String>,
+    // cache for [PropagatedConstant] values from instantiated methods
+    cst_method_cache: HashMap<(FullyQualified, String), PropagatedConstant>,
+    // cache for [PropagatedConstant] values from instantiated functions
+    cst_fn_cache: HashMap<FullyQualified, PropagatedConstant>,
 }
 
 impl<B: Backend> MastCtx<B> {
@@ -278,6 +315,8 @@ impl<B: Backend> MastCtx<B> {
             generic_func_scope: Some(0),
             functions_instantiated: HashMap::new(),
             methods_instantiated: HashMap::new(),
+            cst_method_cache: HashMap::new(),
+            cst_fn_cache: HashMap::new(),
         }
     }
 
@@ -509,7 +548,12 @@ fn monomorphize_expr<B: Backend>(
                 },
             );
 
-            let cst = None;
+            // propagate the constant value
+            let cst = lhs_mono.constant.and_then(|c| match c {
+                PropagatedConstant::Custom(map) => map.get(rhs).cloned(),
+                _ => None,
+            });
+
             ExprMonoInfo::new(mexpr, typ, cst)
         }
 
@@ -558,10 +602,19 @@ fn monomorphize_expr<B: Backend>(
                     .as_ref()
                     .and_then(|sig| sig.return_type.clone().map(|t| t.kind));
 
-                ExprMonoInfo::new(mexpr, typ, None)
+                // retrieve the constant value from the cache
+                let cst = ctx.cst_fn_cache.get(&mono_qualified).cloned();
+
+                ExprMonoInfo::new(mexpr, typ, cst)
             } else {
                 // monomorphize the function call
-                let (fn_info_mono, typ) = instantiate_fn_call(ctx, fn_info, &observed, expr.span)?;
+                let (fn_info_mono, typ, cst) =
+                    instantiate_fn_call(ctx, fn_info, &observed, expr.span)?;
+
+                // cache the constant value
+                if let Some(cst) = cst.clone() {
+                    ctx.cst_fn_cache.insert(mono_qualified.clone(), cst);
+                }
 
                 let fn_name_mono = &fn_info_mono.sig().name;
                 let mexpr = expr.to_mast(
@@ -577,7 +630,7 @@ fn monomorphize_expr<B: Backend>(
                 let new_qualified = FullyQualified::new(module, &fn_name_mono.value);
                 ctx.add_monomorphized_fn(old_qualified, new_qualified, fn_info_mono);
 
-                ExprMonoInfo::new(mexpr, typ, None)
+                ExprMonoInfo::new(mexpr, typ, cst)
             }
         }
 
@@ -649,10 +702,23 @@ fn monomorphize_expr<B: Backend>(
                     },
                 );
                 let typ = resolved_sig.return_type.clone().map(|t| t.kind);
-                ExprMonoInfo::new(mexpr, typ, None)
+
+                // retrieve the constant value from the cache
+                let cst = ctx
+                    .cst_method_cache
+                    .get(&(struct_qualified.clone(), method_name.value.clone()))
+                    .cloned();
+
+                ExprMonoInfo::new(mexpr, typ, cst)
             } else {
                 // monomorphize the function call
-                let (fn_info_mono, typ) = instantiate_fn_call(ctx, fn_info, &observed, expr.span)?;
+                let (fn_info_mono, typ, cst) =
+                    instantiate_fn_call(ctx, fn_info, &observed, expr.span)?;
+                // cache the constant value
+                if let Some(cst) = cst.clone() {
+                    ctx.cst_method_cache
+                        .insert((struct_qualified.clone(), method_name.value.clone()), cst);
+                }
 
                 let fn_name_mono = &fn_info_mono.sig().name;
                 let mexpr = expr.to_mast(
@@ -668,7 +734,7 @@ fn monomorphize_expr<B: Backend>(
                 ctx.tast
                     .add_monomorphized_method(struct_qualified, &fn_name_mono.value, fn_def);
 
-                ExprMonoInfo::new(mexpr, typ, None)
+                ExprMonoInfo::new(mexpr, typ, cst)
             }
         }
 
@@ -739,9 +805,14 @@ fn monomorphize_expr<B: Backend>(
                 Some(v) => {
                     let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(v.clone()));
 
-                    ExprMonoInfo::new(mexpr, typ, v.to_u32())
+                    ExprMonoInfo::new(
+                        mexpr,
+                        typ,
+                        Some(PropagatedConstant::from(v.to_u32().unwrap())),
+                    )
                 }
-                None => {
+                // keep as is
+                _ => {
                     let mexpr = expr.to_mast(
                         ctx,
                         &ExprKind::BinaryOp {
@@ -778,7 +849,11 @@ fn monomorphize_expr<B: Backend>(
             let cst: u32 = inner.try_into().expect("biguint too large");
             let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(inner.clone()));
 
-            ExprMonoInfo::new(mexpr, Some(TyKind::Field { constant: true }), Some(cst))
+            ExprMonoInfo::new(
+                mexpr,
+                Some(TyKind::Field { constant: true }),
+                Some(PropagatedConstant::from(cst)),
+            )
         }
 
         ExprKind::Bool(inner) => {
@@ -794,10 +869,10 @@ fn monomorphize_expr<B: Backend>(
 
             let res = if is_generic_parameter(&name.value) {
                 let mtype = mono_fn_env.get_type_info(&name.value).unwrap();
-                let mexpr =
-                    expr.to_mast(ctx, &ExprKind::BigUInt(BigUint::from(mtype.value.unwrap())));
+                let cst = mtype.constant.clone().unwrap().as_single();
+                let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(BigUint::from(cst)));
 
-                ExprMonoInfo::new(mexpr, Some(mtype.typ.clone()), mtype.value)
+                ExprMonoInfo::new(mexpr, Some(mtype.typ.clone()), mtype.constant.clone())
             } else if is_type(&name.value) {
                 let mtype = TyKind::Custom {
                     module: module.clone(),
@@ -820,7 +895,11 @@ fn monomorphize_expr<B: Backend>(
                 let cst: u32 = bigint.clone().try_into().expect("biguint too large");
                 let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(bigint));
 
-                ExprMonoInfo::new(mexpr, Some(TyKind::Field { constant: true }), Some(cst))
+                ExprMonoInfo::new(
+                    mexpr,
+                    Some(TyKind::Field { constant: true }),
+                    Some(PropagatedConstant::from(cst)),
+                )
             } else {
                 // otherwise it's a local variable
                 let mexpr = expr.to_mast(
@@ -832,7 +911,7 @@ fn monomorphize_expr<B: Backend>(
                 );
 
                 let mtype = mono_fn_env.get_type_info(&name.value).unwrap().clone();
-                ExprMonoInfo::new(mexpr, Some(mtype.typ), mtype.value)
+                ExprMonoInfo::new(mexpr, Some(mtype.typ), mtype.constant)
             };
 
             res
@@ -955,16 +1034,40 @@ fn monomorphize_expr<B: Backend>(
                     ));
                 }
 
-                fields_mono.push((ident, observed_mono.expr.clone()));
+                fields_mono.push((
+                    ident,
+                    observed_mono.expr.clone(),
+                    observed_mono.constant.clone(),
+                ));
             }
 
             let mexpr = expr.to_mast(
                 ctx,
                 &ExprKind::CustomTypeDeclaration {
                     custom: custom.clone(),
-                    fields: fields_mono,
+                    // extract a tuple of first two elements
+                    fields: fields_mono
+                        .iter()
+                        .map(|(a, b, _)| (a.clone(), b.clone()))
+                        .collect(),
                 },
             );
+
+            let cst_fields = {
+                let csts = HashMap::from_iter(
+                    fields_mono
+                        .into_iter()
+                        .filter(|(_, _, cst)| cst.is_some())
+                        .map(|(ident, _, cst)| (ident, cst.unwrap())),
+                );
+                if csts.is_empty() {
+                    None
+                } else {
+                    Some(PropagatedConstant::Custom(csts))
+                }
+            };
+
+            println!("custom type declaration: {:?}", cst_fields);
 
             ExprMonoInfo::new(
                 mexpr,
@@ -972,7 +1075,7 @@ fn monomorphize_expr<B: Backend>(
                     module: module.clone(),
                     name: name.clone(),
                 }),
-                None,
+                cst_fields,
             )
         }
         ExprKind::RepeatedArrayInit { item, size } => {
@@ -989,7 +1092,7 @@ fn monomorphize_expr<B: Backend>(
             );
 
             if let Some(cst) = size_mono.constant {
-                let arr_typ = TyKind::Array(Box::new(item_typ), cst);
+                let arr_typ = TyKind::Array(Box::new(item_typ), cst.as_single());
                 ExprMonoInfo::new(mexpr, Some(arr_typ), None)
             } else {
                 return Err(error(ErrorKind::InvalidArraySize, expr.span));
@@ -1011,22 +1114,29 @@ pub fn monomorphize_block<B: Backend>(
     mono_fn_env: &mut MonomorphizedFnEnv,
     stmts: &[Stmt],
     expected_return: Option<&Ty>,
-) -> Result<(Vec<Stmt>, Option<TyKind>)> {
+) -> Result<(Vec<Stmt>, Option<ExprMonoInfo>)> {
     mono_fn_env.nest();
 
-    let mut return_typ = None;
+    let mut ret_expr_mono = None;
 
     let mut stmts_mono = vec![];
 
     for stmt in stmts {
-        if let Some((stmt, ret_typ)) = monomorphize_stmt(ctx, mono_fn_env, stmt)? {
+        if let Some((stmt, expr_mono)) = monomorphize_stmt(ctx, mono_fn_env, stmt)? {
             stmts_mono.push(stmt);
 
-            if ret_typ.is_some() {
-                return_typ = ret_typ;
+            // only return stmt can return `ExprMonoInfo` which contains propagated constants
+            if expr_mono.is_some() {
+                ret_expr_mono = expr_mono;
             }
         }
     }
+
+    let return_typ = if let Some(expr_mono) = ret_expr_mono.clone() {
+        expr_mono.typ
+    } else {
+        None
+    };
 
     // check the return
     if let (Some(expected), Some(observed)) = (expected_return, return_typ.clone()) {
@@ -1040,7 +1150,7 @@ pub fn monomorphize_block<B: Backend>(
 
     mono_fn_env.pop();
 
-    Ok((stmts_mono, return_typ))
+    Ok((stmts_mono, ret_expr_mono))
 }
 
 /// Monomorphize a statement.
@@ -1048,7 +1158,7 @@ pub fn monomorphize_stmt<B: Backend>(
     ctx: &mut MastCtx<B>,
     mono_fn_env: &mut MonomorphizedFnEnv,
     stmt: &Stmt,
-) -> Result<Option<(Stmt, Option<TyKind>)>> {
+) -> Result<Option<(Stmt, Option<ExprMonoInfo>)>> {
     let res = match &stmt.kind {
         StmtKind::Assign { mutable, lhs, rhs } => {
             let rhs_mono = monomorphize_expr(ctx, rhs, mono_fn_env)?;
@@ -1093,7 +1203,9 @@ pub fn monomorphize_stmt<B: Backend>(
                         return Err(error(ErrorKind::InvalidRangeSize, stmt.span));
                     }
 
-                    if start_mono.constant.unwrap() > end_mono.constant.unwrap() {
+                    if start_mono.constant.unwrap().as_single()
+                        > end_mono.constant.unwrap().as_single()
+                    {
                         return Err(error(ErrorKind::InvalidRangeSize, stmt.span));
                     }
 
@@ -1147,11 +1259,11 @@ pub fn monomorphize_stmt<B: Backend>(
         StmtKind::Return(res) => {
             let expr_mono = monomorphize_expr(ctx, res, mono_fn_env)?;
             let stmt_mono = Stmt {
-                kind: StmtKind::Return(Box::new(expr_mono.expr)),
+                kind: StmtKind::Return(Box::new(expr_mono.expr.clone())),
                 span: stmt.span,
             };
 
-            Some((stmt_mono, expr_mono.typ))
+            Some((stmt_mono, Some(expr_mono)))
         }
         StmtKind::Comment(_) => None,
     };
@@ -1168,7 +1280,7 @@ pub fn instantiate_fn_call<B: Backend>(
     fn_info: FnInfo<B>,
     args: &[ExprMonoInfo],
     span: Span,
-) -> Result<(FnInfo<B>, Option<TyKind>)> {
+) -> Result<(FnInfo<B>, Option<TyKind>, Option<PropagatedConstant>)> {
     ctx.start_monomorphize_func();
 
     let fn_sig = fn_info.sig();
@@ -1192,7 +1304,11 @@ pub fn instantiate_fn_call<B: Backend>(
         let val = fn_sig.generics.get(gen);
         mono_fn_env.store_type(
             gen,
-            &MTypeInfo::new(&TyKind::Field { constant: true }, span, Some(val)),
+            &MTypeInfo::new(
+                &TyKind::Field { constant: true },
+                span,
+                Some(PropagatedConstant::from(val)),
+            ),
         )?;
     }
 
@@ -1208,7 +1324,7 @@ pub fn instantiate_fn_call<B: Backend>(
         let typ = mono_info.typ.as_ref().expect("expected a value");
         mono_fn_env.store_type(
             arg_name,
-            &MTypeInfo::new(typ, mono_info.expr.span, mono_info.constant),
+            &MTypeInfo::new(typ, mono_info.expr.span, mono_info.constant.clone()),
         )?;
     }
 
@@ -1216,32 +1332,40 @@ pub fn instantiate_fn_call<B: Backend>(
     let ret_typed = sig_typed.return_type.clone();
 
     // construct the monomorphized function AST
-    let func_def = match fn_info.kind {
-        FnKind::BuiltIn(_, handle) => FnInfo {
-            kind: FnKind::BuiltIn(sig_typed, handle),
-            is_hint: fn_info.is_hint,
-            span: fn_info.span,
-        },
+    let (func_def, mono_info) = match fn_info.kind {
+        FnKind::BuiltIn(_, handle) => (
+            FnInfo {
+                kind: FnKind::BuiltIn(sig_typed, handle),
+                ..fn_info
+            },
+            // todo: we will need to propagate the constant value from builtin function as well
+            None,
+        ),
         FnKind::Native(fn_def) => {
-            let (stmts_typed, _) =
+            let (stmts_typed, mono_info) =
                 monomorphize_block(ctx, mono_fn_env, &fn_def.body, ret_typed.as_ref())?;
 
-            FnInfo {
-                kind: FnKind::Native(FunctionDef {
-                    sig: sig_typed,
-                    body: stmts_typed,
-                    span: fn_def.span,
-                    is_hint: fn_def.is_hint,
-                }),
-                is_hint: fn_info.is_hint,
-                span: fn_info.span,
-            }
+            (
+                FnInfo {
+                    kind: FnKind::Native(FunctionDef {
+                        sig: sig_typed,
+                        body: stmts_typed,
+                        span: fn_def.span,
+                        is_hint: fn_def.is_hint,
+                    }),
+                    is_hint: fn_info.is_hint,
+                    span: fn_info.span,
+                },
+                mono_info,
+            )
         }
     };
 
     ctx.finish_monomorphize_func();
 
-    Ok((func_def, ret_typed.map(|t| t.kind)))
+    let cst = mono_info.and_then(|c| c.constant);
+
+    Ok((func_def, ret_typed.map(|t| t.kind), cst))
 }
 pub fn error(kind: ErrorKind, span: Span) -> Error {
     Error::new("mast", kind, span)

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -1067,8 +1067,6 @@ fn monomorphize_expr<B: Backend>(
                 }
             };
 
-            println!("custom type declaration: {:?}", cst_fields);
-
             ExprMonoInfo::new(
                 mexpr,
                 Some(TyKind::Custom {

--- a/src/negative_tests.rs
+++ b/src/negative_tests.rs
@@ -498,3 +498,55 @@ fn test_nonhint_call_with_unsafe() {
         ErrorKind::UnexpectedUnsafeAttribute
     ));
 }
+
+#[test]
+fn test_no_cst_struct_field_prop() {
+    let code = r#"
+    struct Thing {
+        val: Field,
+    }
+
+    fn gen(const LEN: Field) -> [Field; LEN] {
+        return [0; LEN];
+    }
+
+    fn main(pub xx: Field) {
+        let thing = Thing { val: xx };
+
+        let arr = gen(thing.val);
+    }
+    "#;
+
+    let res = tast_pass(code).0;
+    assert!(matches!(
+        res.unwrap_err().kind,
+        ErrorKind::ArgumentTypeMismatch(..)
+    ));
+}
+
+#[test]
+fn test_mut_cst_struct_field_prop() {
+    let code = r#"
+    struct Thing {
+        val: Field,
+    }
+
+    fn gen(const LEN: Field) -> [Field; LEN] {
+        return [0; LEN];
+    }
+
+    fn main(pub xx: Field) {
+        let mut thing = Thing { val: 3 };
+        thing.val = xx;
+
+        let arr = gen(thing.val);
+        assert_eq(arr[0], xx);
+    }
+    "#;
+
+    let res = tast_pass(code).0;
+    assert!(matches!(
+        res.unwrap_err().kind,
+        ErrorKind::ArgumentTypeMismatch(..)
+    ));
+}

--- a/src/stdlib/native/int.no
+++ b/src/stdlib/native/int.no
@@ -7,19 +7,21 @@ struct Uint8 {
 }
 
 fn Uint8.new(val: Field) -> Uint8 {
+    let bit_len = 8;
+
     // range check
-    let ignore_ = bits::to_bits(8, val);
+    let ignore_ = bits::to_bits(bit_len, val);
 
     return Uint8 {
         inner: val,
-        bit_len: 8
+        bit_len: bit_len
     };
 }
 
 fn Uint8.less_than(self, rhs: Uint8) -> Bool {
-    return comparator::less_than(8, self.inner, rhs.inner);
+    return comparator::less_than(self.bit_len, self.inner, rhs.inner);
 }
 
 fn Uint8.less_eq_than(self, rhs: Uint8) -> Bool {
-    return comparator::less_eq_than(8, self.inner, rhs.inner);
+    return comparator::less_eq_than(self.bit_len, self.inner, rhs.inner);
 }

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -150,6 +150,29 @@ impl<B: Backend> TypeChecker<B> {
             .expect("couldn't find the struct for storing the method");
         struct_info.methods.remove(method_name);
     }
+
+    /// Update the type of a struct field.
+    /// When the assignment is done, we need to update the type of the field.
+    /// This is only for the case of updating field types to either a constant or a variable.
+    pub fn update_struct_field(
+        &mut self,
+        qualified: &FullyQualified,
+        field_name: &str,
+        typ: TyKind,
+    ) {
+        let struct_info = self
+            .structs
+            .get_mut(qualified)
+            .expect("couldn't find the struct for storing the method");
+
+        // update the field type
+        for field in struct_info.fields.iter_mut() {
+            if field.0 == field_name {
+                field.1 = typ;
+                return;
+            }
+        }
+    }
 }
 
 impl<B: Backend> TypeChecker<B> {


### PR DESCRIPTION
This is a fix to propagate the constant values from struct fields also.

This fix allows the struct fields to be passed as an constant argument for a generic function. eg:

```rust
struct Uint8 {
    inner: Field,
    bit_len: Field,
}

fn Uint8.new(val: Field) -> Uint8 {
    let bit_len = 8;

    // range check
    let ignore_ = bits::to_bits(bit_len, val);

    return Uint8 {
        inner: val,
        bit_len: bit_len
    };
}

fn Uint8.less_than(self, rhs: Uint8) -> Bool {
    // this won't work without this PR fix
    return comparator::less_than(self.bit_len, self.inner, rhs.inner);
}
```