### PR TITLE
supporting debug var value

### DIFF
--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -758,4 +758,13 @@ impl Backend for KimchiVesta {
 
         cvar
     }
+
+    fn log_var(
+        &mut self,
+        var: &crate::circuit_writer::VarInfo<Self::Field, Self::Var>,
+        msg: String,
+        span: Span,
+    ) {
+        todo!()
+    }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -5,6 +5,7 @@ use ark_ff::{Field, One, Zero};
 use num_bigint::BigUint;
 
 use crate::{
+    circuit_writer::VarInfo,
     compiler::Sources,
     constants::Span,
     error::{Error, ErrorKind, Result},
@@ -216,4 +217,6 @@ pub trait Backend: Clone {
 
     /// Generate the asm for a backend.
     fn generate_asm(&self, sources: &Sources, debug: bool) -> String;
+
+    fn log_var(&mut self, var: &VarInfo<Self::Field, Self::Var>, msg: String, span: Span);
 }

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -9,10 +9,10 @@ use itertools::{izip, Itertools as _};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
+use crate::circuit_writer::VarInfo;
 use crate::constants::Span;
 use crate::error::{Error, ErrorKind, Result};
-use crate::helpers::PrettyField;
-use crate::parser::FunctionDef;
+use crate::var::ConstOrCell;
 use crate::{circuit_writer::DebugInfo, var::Value};
 
 use super::{Backend, BackendField, BackendVar};
@@ -224,7 +224,10 @@ where
     /// Constraints in the r1cs.
     constraints: Vec<Constraint<F>>,
     witness_vector: Vec<Value<Self>>,
+    /// Debug information for each constraint.
     debug_info: Vec<DebugInfo>,
+    /// Debug information for var info.
+    log_info: Vec<(String, Span, VarInfo<F, LinearCombination<F>>)>,
     /// Record the public inputs for reordering the witness vector
     public_inputs: Vec<CellVar>,
     /// Record the private inputs for checking
@@ -247,6 +250,7 @@ where
             private_input_cell_vars: Vec::new(),
             public_outputs: Vec::new(),
             finalized: false,
+            log_info: Vec::new(),
         }
     }
 
@@ -463,6 +467,21 @@ where
             witness[var.index] = val;
         }
 
+        // print out the log info
+        for (_, span, var_info) in &self.log_info {
+            for cvar in var_info.var.iter() {
+                match cvar {
+                    ConstOrCell::Const(cst) => {
+                        println!("span:{}, cst: {}", span.start, cst.pretty());
+                    }
+                    ConstOrCell::Cell(cell) => {
+                        let val = cell.evaluate(&witness);
+                        println!("span:{}, val: {}", span.start, val.pretty());
+                    }
+                }
+            }
+        }
+
         for (index, (constraint, debug_info)) in
             izip!(&self.constraints, &self.debug_info).enumerate()
         {
@@ -627,6 +646,10 @@ where
         self.public_outputs.push(*var.to_cell_var());
 
         var
+    }
+
+    fn log_var(&mut self, var: &VarInfo<Self::Field, Self::Var>, msg: String, span: Span) {
+        self.log_info.push((msg, span, var.clone()));
     }
 }
 

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -137,21 +137,9 @@ fn log_fn<B: Backend>(
     vars: &[VarInfo<B::Field, B::Var>],
     span: Span,
 ) -> Result<Option<Var<B::Field, B::Var>>> {
-    println!("---log span: {:?}---", span);
     for var in vars {
-        // typ
-        println!("typ: {:?}", var.typ);
-        // mutable
-        println!("mutable: {:?}", var.mutable);
-        // var
-        var.var.iter().for_each(|v| match v {
-            ConstOrCell::Const(cst) => {
-                println!("cst: {:?}", cst.pretty());
-            }
-            ConstOrCell::Cell(cvar) => {
-                println!("cvar: {:?}", cvar);
-            }
-        });
+        // todo: will need to support string argument in order to customize msg
+        compiler.backend.log_var(var, "log".to_owned(), span);
     }
 
     Ok(None)


### PR DESCRIPTION
Previously, the log function is to print out the compilation info, such as the type of a variable.

This update is to make it print out the witness value instead, which is more useful for debugging purpose.

For example:
```rust
fn mimc7_hash(values: [Field; LEN], key: Field) -> Field {
    // Initialize with the key.
    let mut res = key;
    // Iterate over each value in the input array.
    for value in values {
        // Update the result with the MIMC hash of the value and the current result.
        res = res + (value + mimc7_cipher(value, res));
        log(res);
    }
    // Return the final accumulated result.
    return res;
}
```

It will print out:
```
span:9904, val: -9648106414739122877149794902860786266420046965962985658208312984077979135149
span:9904, val: 5233261170300319370386085858846328736737478911451874673953613863492170606314
span:9904, val: -4718642457857295476661913076129034983054319651083126928208304929878678658037
```


Currently it only support logging Field type. These info is rough still. 
Later we can make it print out more meta data, such as which file the span belonging to and what type of the var etc.