### PR TITLE
better log output

### DIFF
--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -392,6 +392,7 @@ impl Backend for KimchiVesta {
     fn generate_witness(
         &self,
         witness_env: &mut WitnessEnv<VestaField>,
+        sources: &Sources,
     ) -> Result<GeneratedWitness> {
         if !self.finalized {
             unreachable!("the circuit must be finalized before generating a witness");

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -368,6 +368,7 @@ pub trait Backend: Clone {
     fn generate_witness(
         &self,
         witness_env: &mut WitnessEnv<Self::Field>,
+        sources: &Sources,
     ) -> Result<Self::GeneratedWitness>;
 
     /// Generate the asm for a backend.

--- a/src/backends/r1cs/arkworks.rs
+++ b/src/backends/r1cs/arkworks.rs
@@ -130,8 +130,9 @@ mod tests {
 
         let json_public = parse_inputs(inputs_public).unwrap();
         let json_private = parse_inputs(inputs_private).unwrap();
+        let sources = Sources::new();
         let generated_witness = compiled_circuit
-            .generate_witness(json_public, json_private)
+            .generate_witness(&sources, json_public, json_private)
             .unwrap();
 
         let noname_circuit = NoNameCircuit {
@@ -153,8 +154,9 @@ mod tests {
 
         let json_public = parse_inputs(inputs_public).unwrap();
         let json_private = parse_inputs(inputs_private).unwrap();
+        let sources = Sources::new();
         let generated_witness = compiled_circuit
-            .generate_witness(json_public, json_private)
+            .generate_witness(&sources, json_public, json_private)
             .unwrap();
         let noname_circuit = NoNameCircuit {
             compiled_circuit,

--- a/src/circuit_writer/mod.rs
+++ b/src/circuit_writer/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     backends::Backend,
+    compiler::Sources,
     constants::Span,
     error::{Error, ErrorKind, Result},
     mast::Mast,
@@ -217,8 +218,9 @@ impl<B: Backend> CircuitWriter<B> {
     pub fn generate_witness(
         &self,
         witness_env: &mut WitnessEnv<B::Field>,
+        sources: &Sources,
     ) -> Result<B::GeneratedWitness> {
-        self.backend.generate_witness(witness_env)
+        self.backend.generate_witness(witness_env, sources)
     }
 
     fn handle_arg(

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -231,6 +231,6 @@ pub fn generate_witness<B: Backend>(
     private_inputs: JsonInputs,
 ) -> miette::Result<B::GeneratedWitness> {
     compiled_circuit
-        .generate_witness(public_inputs, private_inputs)
+        .generate_witness(sources, public_inputs, private_inputs)
         .into_miette(sources)
 }

--- a/src/tests/examples.rs
+++ b/src/tests/examples.rs
@@ -133,7 +133,7 @@ fn test_file(
 
             // this should check the constraints
             let generated_witness = compiled_circuit
-                .generate_witness(public_inputs.clone(), private_inputs.clone())
+                .generate_witness(&sources, public_inputs.clone(), private_inputs.clone())
                 .unwrap();
 
             // check the ASM

--- a/src/tests/stdlib/mod.rs
+++ b/src/tests/stdlib/mod.rs
@@ -83,8 +83,11 @@ fn test_stdlib_code(
     let compiled_circuit = CircuitWriter::generate_circuit(mast, r1cs)?;
 
     // this should check the constraints
-    let generated_witness =
-        compiled_circuit.generate_witness(public_inputs.clone(), private_inputs.clone())?;
+    let generated_witness = compiled_circuit.generate_witness(
+        &sources,
+        public_inputs.clone(),
+        private_inputs.clone(),
+    )?;
 
     let expected_public_output = expected_public_output
         .iter()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,7 +41,7 @@ pub fn display_source(
     res.push('\n');
 }
 
-fn find_exact_line(source: &str, span: crate::constants::Span) -> (usize, usize, &str) {
+pub(crate) fn find_exact_line(source: &str, span: crate::constants::Span) -> (usize, usize, &str) {
     let ss = source.as_bytes();
     let mut start = span.start;
     let mut end = span.end();

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -57,6 +57,7 @@ impl<B: Backend> CompiledCircuit<B> {
 
     pub fn generate_witness(
         &self,
+        sources: &Sources,
         mut public_inputs: JsonInputs,
         mut private_inputs: JsonInputs,
     ) -> Result<B::GeneratedWitness> {
@@ -107,6 +108,6 @@ impl<B: Backend> CompiledCircuit<B> {
             ));
         }
 
-        self.circuit.generate_witness(&mut env)
+        self.circuit.generate_witness(&mut env, sources)
     }
 }


### PR DESCRIPTION
this adds some problem when we will split the `run` into `compile` and `run` commands. Right now we have access to the sources BECAUSE we produce the witness in the same command that compiles the circuit.

If we compile the circuit in one command (producing a compiled circuit artifact), then try to generate a witness in another command we might not have access to `Sources` anymore.

The solution will probably be to precompute what we need from sources in advance and add that to the `debug_info`