### PR TITLE
Add --disable-safety-check option

### DIFF
--- a/examples/fixture/asm/kimchi/unused_variables.asm
+++ b/examples/fixture/asm/kimchi/unused_variables.asm
@@ -1,0 +1,7 @@
+@ noname.0.7.0
+@ public inputs: 1
+
+DoubleGeneric<1>
+DoubleGeneric<1,0,-1,0,1>
+DoubleGeneric<1,0,0,0,-2>
+(0,0) -> (2,0)

--- a/examples/fixture/asm/r1cs/unused_variables.asm
+++ b/examples/fixture/asm/r1cs/unused_variables.asm
@@ -1,0 +1,4 @@
+@ noname.0.7.0
+@ public inputs: 1
+
+2 == (v_1) * (1)

--- a/examples/unused_variables.no
+++ b/examples/unused_variables.no
@@ -1,0 +1,4 @@
+fn main(pub xx: Field, yy: Field) {
+    let zz = yy + 1;
+    assert_eq(xx, 2);
+}

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -358,25 +358,21 @@ impl Backend for KimchiVesta {
         }
 
         for var in 0..self.next_variable {
-            if !written_vars.contains(&var) {
+            if !written_vars.contains(&var) && !disable_safety_check {
                 if let Some(private_cell_var) = self
                     .private_input_cell_vars
                     .iter()
                     .find(|private_cell_var| private_cell_var.index == var)
                 {
                     // TODO: is this error useful?
-                    if !disable_safety_check {
-                        let err = Error::new(
-                            "constraint-finalization",
-                            ErrorKind::PrivateInputNotUsed,
-                            private_cell_var.span,
-                        );
-                        Err(err)?;
-                    }
+                    let err = Error::new(
+                        "constraint-finalization",
+                        ErrorKind::PrivateInputNotUsed,
+                        private_cell_var.span,
+                    );
+                    Err(err)?;
                 } else {
-                    if !disable_safety_check {
-                        Err(Error::new("contraint-finalization", ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"), Span::default()))?;
-                    }
+                    Err(Error::new("contraint-finalization", ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"), Span::default()))?;
                 }
             }
         }

--- a/src/backends/kimchi/mod.rs
+++ b/src/backends/kimchi/mod.rs
@@ -335,6 +335,7 @@ impl Backend for KimchiVesta {
         &mut self,
         public_output: Option<Var<Self::Field, Self::Var>>,
         returned_cells: Option<Vec<KimchiCellVar>>,
+        disable_safety_check: bool,
     ) -> Result<()> {
         // TODO: the current tests pass even this is commented out. Add a test case for this one.
         // important: there might still be a pending generic gate
@@ -364,14 +365,18 @@ impl Backend for KimchiVesta {
                     .find(|private_cell_var| private_cell_var.index == var)
                 {
                     // TODO: is this error useful?
-                    let err = Error::new(
-                        "constraint-finalization",
-                        ErrorKind::PrivateInputNotUsed,
-                        private_cell_var.span,
-                    );
-                    Err(err)?;
+                    if !disable_safety_check {
+                        let err = Error::new(
+                            "constraint-finalization",
+                            ErrorKind::PrivateInputNotUsed,
+                            private_cell_var.span,
+                        );
+                        Err(err)?;
+                    }
                 } else {
-                    Err(Error::new("contraint-finalization", ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"), Span::default()))?;
+                    if !disable_safety_check {
+                        Err(Error::new("contraint-finalization", ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"), Span::default()))?;
+                    }
                 }
             }
         }

--- a/src/backends/kimchi/prover.rs
+++ b/src/backends/kimchi/prover.rs
@@ -269,7 +269,7 @@ mod tests {
         .unwrap();
 
         let kimchi_vesta = KimchiVesta::new(false);
-        let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None)?;
+        let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None, false)?;
 
         let (prover_index, _) = compiled_circuit.compile_to_indexes().unwrap();
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -407,6 +407,7 @@ pub trait Backend: Clone {
         &mut self,
         public_output: Option<Var<Self::Field, Self::Var>>,
         returned_cells: Option<Vec<Self::Var>>,
+        disable_safety_check: bool,
     ) -> Result<()>;
 
     /// Generate the witness for a backend.

--- a/src/backends/r1cs/arkworks.rs
+++ b/src/backends/r1cs/arkworks.rs
@@ -91,6 +91,7 @@ pub const WITH_PUBLIC_OUTPUT_ARRAY: &str =
 
 pub fn compile_source_code<BF: BackendField>(
     code: &str,
+    disable_safety_check: bool,
 ) -> Result<CompiledCircuit<R1CS<BF>>, crate::error::Error> {
     let mut sources = Sources::new();
 
@@ -111,7 +112,7 @@ pub fn compile_source_code<BF: BackendField>(
     let mast = mast::monomorphize(tast)?;
     let r1cs = R1CS::<BF>::new();
     // compile
-    CircuitWriter::generate_circuit(mast, r1cs)
+    CircuitWriter::generate_circuit(mast, r1cs, disable_safety_check)
 }
 
 #[cfg(test)]
@@ -124,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_arkworks_cs_is_satisfied() {
-        let compiled_circuit = compile_source_code::<R1csBn254Field>(SIMPLE_ADDITION).unwrap();
+        let compiled_circuit = compile_source_code::<R1csBn254Field>(SIMPLE_ADDITION, false).unwrap();
         let inputs_public = r#"{"public_input": "2"}"#;
         let inputs_private = r#"{"private_input": "2"}"#;
 
@@ -148,7 +149,7 @@ mod tests {
     #[test]
     fn test_arkworks_cs_is_satisfied_array() {
         let compiled_circuit =
-            compile_source_code::<R1csBn254Field>(WITH_PUBLIC_OUTPUT_ARRAY).unwrap();
+            compile_source_code::<R1csBn254Field>(WITH_PUBLIC_OUTPUT_ARRAY, false).unwrap();
         let inputs_public = r#"{"public_input": ["2", "5"]}"#;
         let inputs_private = r#"{"private_input": ["8", "2"]}"#;
 

--- a/src/backends/r1cs/arkworks.rs
+++ b/src/backends/r1cs/arkworks.rs
@@ -125,7 +125,8 @@ mod tests {
 
     #[test]
     fn test_arkworks_cs_is_satisfied() {
-        let compiled_circuit = compile_source_code::<R1csBn254Field>(SIMPLE_ADDITION, false).unwrap();
+        let compiled_circuit =
+            compile_source_code::<R1csBn254Field>(SIMPLE_ADDITION, false).unwrap();
         let inputs_public = r#"{"public_input": "2"}"#;
         let inputs_private = r#"{"private_input": "2"}"#;
 

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -407,6 +407,7 @@ where
         &mut self,
         public_output: Option<crate::var::Var<Self::Field, Self::Var>>,
         returned_cells: Option<Vec<LinearCombination<F>>>,
+        disable_safety_check: bool,
     ) -> crate::error::Result<()> {
         // store the return value in the public input that was created for that
         if let Some(public_output) = public_output {
@@ -446,17 +447,21 @@ where
                     .iter()
                     .find(|private_cell_var| private_cell_var.index == index)
                 {
-                    Err(Error::new(
-                        "constraint-finalization",
-                        ErrorKind::PrivateInputNotUsed,
-                        private_cell_var.span,
-                    ))?
+                    if !disable_safety_check {
+                        Err(Error::new(
+                            "constraint-finalization",
+                            ErrorKind::PrivateInputNotUsed,
+                            private_cell_var.span,
+                        ))?
+                    }
                 } else {
-                    Err(Error::new(
-                        "constraint-finalization",
-                        ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"),
-                        Span::default(),
-                    ))?
+                    if !disable_safety_check {
+                        Err(Error::new(
+                            "constraint-finalization",
+                            ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"),
+                            Span::default(),
+                        ))?
+                    }
                 }
             }
         }

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -441,27 +441,23 @@ where
                 continue;
             }
 
-            if !written_vars.contains(&index) {
+            if !written_vars.contains(&index) && !disable_safety_check {
                 if let Some(private_cell_var) = self
                     .private_input_cell_vars
                     .iter()
                     .find(|private_cell_var| private_cell_var.index == index)
                 {
-                    if !disable_safety_check {
-                        Err(Error::new(
-                            "constraint-finalization",
-                            ErrorKind::PrivateInputNotUsed,
-                            private_cell_var.span,
-                        ))?
-                    }
+                    Err(Error::new(
+                        "constraint-finalization",
+                        ErrorKind::PrivateInputNotUsed,
+                        private_cell_var.span,
+                    ))?
                 } else {
-                    if !disable_safety_check {
-                        Err(Error::new(
-                            "constraint-finalization",
-                            ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"),
-                            Span::default(),
-                        ))?
-                    }
+                    Err(Error::new(
+                        "constraint-finalization",
+                        ErrorKind::UnexpectedError("there's a bug in the circuit_writer, some cellvar does not end up being a cellvar in the circuit!"),
+                        Span::default(),
+                    ))?
                 }
             }
         }

--- a/src/circuit_writer/mod.rs
+++ b/src/circuit_writer/mod.rs
@@ -124,7 +124,6 @@ impl<B: Backend> CircuitWriter<B> {
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("constraint-generation", kind, span)
     }
-
 }
 
 impl<B: Backend> CircuitWriter<B> {
@@ -140,7 +139,11 @@ impl<B: Backend> CircuitWriter<B> {
         }
     }
 
-    pub fn generate_circuit(typed: Mast<B>, backend: B, disable_safety_check: bool) -> Result<CompiledCircuit<B>> {
+    pub fn generate_circuit(
+        typed: Mast<B>,
+        backend: B,
+        disable_safety_check: bool,
+    ) -> Result<CompiledCircuit<B>> {
         // create circuit writer
         let mut circuit_writer = CircuitWriter::new(typed, backend);
 
@@ -213,9 +216,11 @@ impl<B: Backend> CircuitWriter<B> {
             }
         }
 
-        circuit_writer
-            .backend
-            .finalize_circuit(public_output, returned_cells, disable_safety_check)?;
+        circuit_writer.backend.finalize_circuit(
+            public_output,
+            returned_cells,
+            disable_safety_check,
+        )?;
 
         //
         Ok(CompiledCircuit::new(circuit_writer))

--- a/src/circuit_writer/mod.rs
+++ b/src/circuit_writer/mod.rs
@@ -124,6 +124,7 @@ impl<B: Backend> CircuitWriter<B> {
     pub fn error(&self, kind: ErrorKind, span: Span) -> Error {
         Error::new("constraint-generation", kind, span)
     }
+
 }
 
 impl<B: Backend> CircuitWriter<B> {
@@ -139,7 +140,7 @@ impl<B: Backend> CircuitWriter<B> {
         }
     }
 
-    pub fn generate_circuit(typed: Mast<B>, backend: B) -> Result<CompiledCircuit<B>> {
+    pub fn generate_circuit(typed: Mast<B>, backend: B, disable_safety_check: bool) -> Result<CompiledCircuit<B>> {
         // create circuit writer
         let mut circuit_writer = CircuitWriter::new(typed, backend);
 
@@ -214,7 +215,7 @@ impl<B: Backend> CircuitWriter<B> {
 
         circuit_writer
             .backend
-            .finalize_circuit(public_output, returned_cells)?;
+            .finalize_circuit(public_output, returned_cells, disable_safety_check)?;
 
         //
         Ok(CompiledCircuit::new(circuit_writer))

--- a/src/cli/cmd_build_and_check.rs
+++ b/src/cli/cmd_build_and_check.rs
@@ -91,8 +91,13 @@ pub fn cmd_build(args: CmdBuild) -> miette::Result<()> {
     };
 
     // build
-    let (sources, prover_index, verifier_index) =
-        build(&curr_dir, args.asm, args.debug, &mut server_mode, args.disable_safety_check)?;
+    let (sources, prover_index, verifier_index) = build(
+        &curr_dir,
+        args.asm,
+        args.debug,
+        &mut server_mode,
+        args.disable_safety_check,
+    )?;
 
     // create COMPILED_DIR
     let compiled_path = curr_dir.join(COMPILED_DIR);
@@ -268,7 +273,13 @@ pub fn build(
     let double_generic_gate_optimization = false;
 
     let kimchi_vesta = KimchiVesta::new(double_generic_gate_optimization);
-    let compiled_circuit = compile(&sources, tast, kimchi_vesta, server_mode, disable_safety_check)?;
+    let compiled_circuit = compile(
+        &sources,
+        tast,
+        kimchi_vesta,
+        server_mode,
+        disable_safety_check,
+    )?;
 
     if asm {
         println!("{}", compiled_circuit.asm(&sources, debug));
@@ -333,7 +344,13 @@ pub fn cmd_test(args: CmdTest) -> miette::Result<()> {
         BackendKind::KimchiVesta(_) => {
             let (tast, sources) = typecheck_file(&args.path)?;
             let kimchi_vesta = KimchiVesta::new(args.double);
-            let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None, args.disable_safety_check)?;
+            let compiled_circuit = compile(
+                &sources,
+                tast,
+                kimchi_vesta,
+                &mut None,
+                args.disable_safety_check,
+            )?;
 
             let (prover_index, verifier_index) = compiled_circuit.compile_to_indexes()?;
             println!("successfully compiled");
@@ -352,10 +369,24 @@ pub fn cmd_test(args: CmdTest) -> miette::Result<()> {
             println!("proof verified");
         }
         BackendKind::R1csBls12_381(r1cs) => {
-            test_r1cs_backend(r1cs, &args.path, public_inputs, private_inputs, args.debug, args.disable_safety_check)?;
+            test_r1cs_backend(
+                r1cs,
+                &args.path,
+                public_inputs,
+                private_inputs,
+                args.debug,
+                args.disable_safety_check,
+            )?;
         }
         BackendKind::R1csBn254(r1cs) => {
-            test_r1cs_backend(r1cs, &args.path, public_inputs, private_inputs, args.debug, args.disable_safety_check)?;
+            test_r1cs_backend(
+                r1cs,
+                &args.path,
+                public_inputs,
+                private_inputs,
+                args.debug,
+                args.disable_safety_check,
+            )?;
         }
     }
 
@@ -408,12 +439,20 @@ pub fn cmd_run(args: CmdRun) -> miette::Result<()> {
         BackendKind::KimchiVesta(_) => {
             unimplemented!("kimchi-vesta backend is not yet supported for this command")
         }
-        BackendKind::R1csBls12_381(r1cs) => {
-            run_r1cs_backend(r1cs, &curr_dir, public_inputs, private_inputs, args.disable_safety_check)?
-        }
-        BackendKind::R1csBn254(r1cs) => {
-            run_r1cs_backend(r1cs, &curr_dir, public_inputs, private_inputs, args.disable_safety_check)?
-        }
+        BackendKind::R1csBls12_381(r1cs) => run_r1cs_backend(
+            r1cs,
+            &curr_dir,
+            public_inputs,
+            private_inputs,
+            args.disable_safety_check,
+        )?,
+        BackendKind::R1csBn254(r1cs) => run_r1cs_backend(
+            r1cs,
+            &curr_dir,
+            public_inputs,
+            private_inputs,
+            args.disable_safety_check,
+        )?,
     }
 
     Ok(())

--- a/src/cli/cmd_build_and_check.rs
+++ b/src/cli/cmd_build_and_check.rs
@@ -72,6 +72,7 @@ pub struct CmdBuild {
     #[clap(long)]
     server_mode: bool,
 
+    /// WARNING: This option disables safety checks that ensure each variable is properly constrained.
     /// Do not check that every variable is in a constraint
     #[arg(long = "disable-safety-check", global = true)]
     disable_safety_check: bool,
@@ -321,6 +322,7 @@ pub struct CmdTest {
     #[clap(long)]
     double: bool,
 
+    /// WARNING: This option disables safety checks that ensure each variable is properly constrained.
     /// Do not check that every variable is in a constraint
     #[arg(long = "disable-safety-check", global = true)]
     disable_safety_check: bool,
@@ -412,6 +414,7 @@ pub struct CmdRun {
     #[clap(long, value_parser, default_value = "{}")]
     private_inputs: Option<String>,
 
+    /// WARNING: This option disables safety checks that ensure each variable is properly constrained.
     /// Do not check that every variable is in a constraint
     #[arg(long = "disable-safety-check", global = true)]
     disable_safety_check: bool,

--- a/src/cli/cmd_prove_and_verify.rs
+++ b/src/cli/cmd_prove_and_verify.rs
@@ -27,6 +27,7 @@ pub struct CmdProve {
     #[clap(long, value_parser, default_value = "{}")]
     private_inputs: String,
 
+    /// WARNING: This option disables safety checks that ensure each variable is properly constrained.
     /// Do not check that every variable is in a constraint
     #[arg(long = "disable-safety-check", global = true)]
     disable_safety_check: bool,
@@ -97,6 +98,7 @@ pub struct CmdVerify {
     #[clap(short, long, value_parser)]
     public_output: Option<String>,
 
+    /// WARNING: This option disables safety checks that ensure each variable is properly constrained.
     /// Do not check that every variable is in a constraint
     #[arg(long = "disable-safety-check", global = true)]
     disable_safety_check: bool,

--- a/src/cli/cmd_prove_and_verify.rs
+++ b/src/cli/cmd_prove_and_verify.rs
@@ -26,6 +26,10 @@ pub struct CmdProve {
     /// JSON encoding of the private inputs. Similar to `--public-inputs` but for private inputs.
     #[clap(long, value_parser, default_value = "{}")]
     private_inputs: String,
+
+    /// Do not check that every variable is in a constraint
+    #[arg(long = "disable-safety-check", global = true)]
+    disable_safety_check: bool,
 }
 
 pub fn cmd_prove(args: CmdProve) -> miette::Result<()> {
@@ -33,7 +37,7 @@ pub fn cmd_prove(args: CmdProve) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (sources, prover_index, verifier_index) = build(&curr_dir, false, args.debug, &mut None)?;
+    let (sources, prover_index, verifier_index) = build(&curr_dir, false, args.debug, &mut None, args.disable_safety_check)?;
 
     // parse inputs
     let public_inputs = parse_inputs(&args.public_inputs).unwrap();
@@ -86,6 +90,10 @@ pub struct CmdVerify {
     /// An optional expected public output, in JSON format.
     #[clap(short, long, value_parser)]
     public_output: Option<String>,
+
+    /// Do not check that every variable is in a constraint
+    #[arg(long = "disable-safety-check", global = true)]
+    disable_safety_check: bool,
 }
 
 pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
@@ -93,7 +101,7 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (_sources, _prover_index, verifier_index) = build(&curr_dir, false, false, &mut None)?;
+    let (_sources, _prover_index, verifier_index) = build(&curr_dir, false, false, &mut None, args.disable_safety_check)?;
 
     // parse inputs
     let mut public_inputs = parse_inputs(&args.public_inputs).unwrap();

--- a/src/cli/cmd_prove_and_verify.rs
+++ b/src/cli/cmd_prove_and_verify.rs
@@ -37,7 +37,13 @@ pub fn cmd_prove(args: CmdProve) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (sources, prover_index, verifier_index) = build(&curr_dir, false, args.debug, &mut None, args.disable_safety_check)?;
+    let (sources, prover_index, verifier_index) = build(
+        &curr_dir,
+        false,
+        args.debug,
+        &mut None,
+        args.disable_safety_check,
+    )?;
 
     // parse inputs
     let public_inputs = parse_inputs(&args.public_inputs).unwrap();
@@ -101,7 +107,13 @@ pub fn cmd_verify(args: CmdVerify) -> miette::Result<()> {
         .path
         .unwrap_or_else(|| std::env::current_dir().unwrap().try_into().unwrap());
 
-    let (_sources, _prover_index, verifier_index) = build(&curr_dir, false, false, &mut None, args.disable_safety_check)?;
+    let (_sources, _prover_index, verifier_index) = build(
+        &curr_dir,
+        false,
+        false,
+        &mut None,
+        args.disable_safety_check,
+    )?;
 
     // parse inputs
     let mut public_inputs = parse_inputs(&args.public_inputs).unwrap();

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -210,6 +210,7 @@ pub fn compile<B: Backend>(
     tast: TypeChecker<B>,
     backend: B,
     server_mode: &mut Option<crate::server::ServerShim>,
+    disable_safety_check: bool,
 ) -> miette::Result<CompiledCircuit<B>> {
     // monomorphization pass
     let mast = mast::monomorphize(tast)?;
@@ -228,7 +229,7 @@ pub fn compile<B: Backend>(
     serde_json::to_string(&mast).unwrap();
 
     // synthesizer pass
-    CircuitWriter::generate_circuit(mast, backend).into_miette(sources)
+    CircuitWriter::generate_circuit(mast, backend, disable_safety_check).into_miette(sources)
 }
 
 pub fn generate_witness<B: Backend>(

--- a/src/negative_tests.rs
+++ b/src/negative_tests.rs
@@ -57,7 +57,7 @@ fn mast_pass(code: &str) -> Result<Mast<R1csBackend>> {
 
 fn synthesizer_pass(code: &str) -> Result<CompiledCircuit<R1csBackend>> {
     let mast = mast_pass(code);
-    CircuitWriter::generate_circuit(mast?, R1CS::new())
+    CircuitWriter::generate_circuit(mast?, R1CS::new(), false)
 }
 
 #[test]

--- a/src/tests/examples.rs
+++ b/src/tests/examples.rs
@@ -22,7 +22,9 @@ pub struct TestOptions {
 
 impl TestOptions {
     pub const fn new(disable_safety_check_arg: bool) -> Self {
-        Self { disable_safety_check: disable_safety_check_arg }
+        Self {
+            disable_safety_check: disable_safety_check_arg,
+        }
     }
 }
 
@@ -73,7 +75,13 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None, options.disable_safety_check)?;
+            let compiled_circuit = compile(
+                &sources,
+                tast,
+                kimchi_vesta,
+                &mut None,
+                options.disable_safety_check,
+            )?;
 
             let (prover_index, verifier_index) = compiled_circuit.compile_to_indexes().unwrap();
 
@@ -144,7 +152,13 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, r1cs, &mut None, options.disable_safety_check)?;
+            let compiled_circuit = compile(
+                &sources,
+                tast,
+                r1cs,
+                &mut None,
+                options.disable_safety_check,
+            )?;
 
             // this should check the constraints
             let generated_witness = compiled_circuit
@@ -210,7 +224,13 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, r1cs, &mut None, options.disable_safety_check)?;
+            let compiled_circuit = compile(
+                &sources,
+                tast,
+                r1cs,
+                &mut None,
+                options.disable_safety_check,
+            )?;
 
             // this should check the constraints
             let generated_witness = compiled_circuit
@@ -264,7 +284,14 @@ fn test_arithmetic(#[case] backend: BackendKind) -> miette::Result<()> {
     let public_inputs = r#"{"public_input": "2"}"#;
     let private_inputs = r#"{"private_input": "2"}"#;
 
-    test_file("arithmetic", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "arithmetic",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -322,7 +349,14 @@ fn test_poseidon(#[case] backend: BackendKind) -> miette::Result<()> {
 
     let public_inputs = &format!(r#"{{"public_input": "{digest_dec}"}}"#);
 
-    test_file("poseidon", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "poseidon",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -334,7 +368,14 @@ fn test_bool(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": false}"#;
     let public_inputs = r#"{"public_input": true}"#;
 
-    test_file("bool", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "bool",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -346,7 +387,14 @@ fn test_mutable(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"xx": "2", "yy": "3"}"#;
     let public_inputs = r#"{}"#;
 
-    test_file("mutable", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "mutable",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -358,7 +406,14 @@ fn test_for_loop(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": ["2", "3", "4"]}"#;
     let public_inputs = r#"{"public_input": "9"}"#;
 
-    test_file("for_loop", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "for_loop",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -370,7 +425,14 @@ fn test_dup_var(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": ["1", "2", "2"]}"#;
     let public_inputs = r#"{"public_input": "10"}"#;
 
-    test_file("dup_var", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "dup_var",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -382,7 +444,14 @@ fn test_array(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"public_input": ["1", "2"]}"#;
 
-    test_file("array", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "array",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -394,7 +463,14 @@ fn test_equals(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": ["3", "3"]}"#;
 
-    test_file("equals", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "equals",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -406,7 +482,14 @@ fn test_not_equal(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": ["1", "2"]}"#;
 
-    test_file("not_equal", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "not_equal",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -418,7 +501,14 @@ fn test_types(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1", "yy": "2"}"#;
 
-    test_file("types", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "types",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -450,7 +540,14 @@ fn test_functions(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"one": "1"}"#;
 
-    test_file("functions", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "functions",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -462,7 +559,14 @@ fn test_methods(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1"}"#;
 
-    test_file("methods", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "methods",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -513,7 +617,14 @@ fn test_assignment(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "2"}"#;
 
-    test_file("assignment", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "assignment",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -545,7 +656,14 @@ fn test_if_else(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1"}"#;
 
-    test_file("if_else", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "if_else",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -557,7 +675,14 @@ fn test_sudoku(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"solution": { "inner": ["9", "5", "3", "6", "2", "1", "7", "8", "4", "1", "4", "8", "7", "5", "9", "2", "6", "3", "2", "7", "6", "8", "3", "4", "9", "5", "1", "3", "6", "9", "2", "7", "5", "4", "1", "8", "4", "8", "5", "9", "1", "6", "3", "7", "2", "7", "1", "2", "3", "4", "8", "6", "9", "5", "6", "3", "7", "1", "8", "2", "5", "4", "9", "5", "2", "1", "4", "9", "7", "8", "3", "6", "8", "9", "4", "5", "6", "3", "1", "2", "7"] }}"#;
     let public_inputs = r#"{"grid": { "inner": ["0", "5", "3", "6", "2", "1", "7", "8", "4", "0", "4", "8", "7", "5", "9", "2", "6", "3", "2", "7", "6", "8", "3", "4", "9", "5", "1", "3", "6", "9", "2", "7", "0", "4", "1", "8", "4", "8", "5", "9", "1", "6", "3", "7", "2", "0", "1", "2", "3", "4", "8", "6", "9", "5", "6", "3", "0", "1", "8", "2", "5", "4", "9", "5", "2", "1", "4", "9", "0", "8", "3", "6", "8", "9", "4", "5", "6", "3", "1", "2", "7"] }}"#;
 
-    test_file("sudoku", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "sudoku",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -569,7 +694,14 @@ fn test_literals(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"public_input": "42"}"#;
 
-    test_file("literals", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "literals",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -835,7 +967,7 @@ fn test_generic_nested_method(#[case] backend: BackendKind) -> miette::Result<()
         vec!["1", "1", "1"],
         backend,
         DEFAULT_OPTIONS,
-        )?;
+    )?;
 
     Ok(())
 }
@@ -848,7 +980,14 @@ fn test_hint_fn(#[case] backend: BackendKind) -> miette::Result<()> {
     let public_inputs = r#"{"public_input": "2"}"#;
     let private_inputs = r#"{"private_input": "2"}"#;
 
-    test_file("hint", public_inputs, private_inputs, vec!["8"], backend, DEFAULT_OPTIONS)?;
+    test_file(
+        "hint",
+        public_inputs,
+        private_inputs,
+        vec!["8"],
+        backend,
+        DEFAULT_OPTIONS,
+    )?;
 
     Ok(())
 }
@@ -856,11 +995,20 @@ fn test_hint_fn(#[case] backend: BackendKind) -> miette::Result<()> {
 #[rstest]
 #[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
 #[case::r1cs_bls(BackendKind::R1csBls12_381(R1CS::new()))]
-fn test_unused_variables_with_disabled_safety_check(#[case] backend: BackendKind) -> miette::Result<()> {
+fn test_unused_variables_with_disabled_safety_check(
+    #[case] backend: BackendKind,
+) -> miette::Result<()> {
     let public_inputs = r#"{"xx": "2"}"#;
     let private_inputs = r#"{"yy": "1"}"#;
 
-    test_file("unused_variables", public_inputs, private_inputs, vec![], backend, DISABLE_SAFETY_CHECK_OPTIONS)?;
+    test_file(
+        "unused_variables",
+        public_inputs,
+        private_inputs,
+        vec![],
+        backend,
+        DISABLE_SAFETY_CHECK_OPTIONS,
+    )?;
 
     Ok(())
 }

--- a/src/tests/examples.rs
+++ b/src/tests/examples.rs
@@ -210,7 +210,7 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, r1cs, &mut None)?;
+            let compiled_circuit = compile(&sources, tast, r1cs, &mut None, options.disable_safety_check)?;
 
             // this should check the constraints
             let generated_witness = compiled_circuit
@@ -532,6 +532,7 @@ fn test_augmented_assign(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         expected_public_output,
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())

--- a/src/tests/examples.rs
+++ b/src/tests/examples.rs
@@ -15,12 +15,27 @@ use crate::{
     type_checker::TypeChecker,
 };
 
+pub struct TestOptions {
+    ///Disable safety checks
+    pub disable_safety_check: bool,
+}
+
+impl TestOptions {
+    pub const fn new(disable_safety_check_arg: bool) -> Self {
+        Self { disable_safety_check: disable_safety_check_arg }
+    }
+}
+
+const DEFAULT_OPTIONS: TestOptions = TestOptions::new(false);
+const DISABLE_SAFETY_CHECK_OPTIONS: TestOptions = TestOptions::new(true);
+
 fn test_file(
     file_name: &str,
     public_inputs: &str,
     private_inputs: &str,
     expected_public_output: Vec<&str>,
     backend: BackendKind,
+    options: TestOptions,
 ) -> miette::Result<()> {
     let version = env!("CARGO_MANIFEST_DIR");
     let prefix_examples = Path::new(version).join("examples");
@@ -58,7 +73,7 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None)?;
+            let compiled_circuit = compile(&sources, tast, kimchi_vesta, &mut None, options.disable_safety_check)?;
 
             let (prover_index, verifier_index) = compiled_circuit.compile_to_indexes().unwrap();
 
@@ -129,7 +144,7 @@ fn test_file(
             )
             .unwrap();
 
-            let compiled_circuit = compile(&sources, tast, r1cs, &mut None)?;
+            let compiled_circuit = compile(&sources, tast, r1cs, &mut None, options.disable_safety_check)?;
 
             // this should check the constraints
             let generated_witness = compiled_circuit
@@ -249,7 +264,7 @@ fn test_arithmetic(#[case] backend: BackendKind) -> miette::Result<()> {
     let public_inputs = r#"{"public_input": "2"}"#;
     let private_inputs = r#"{"private_input": "2"}"#;
 
-    test_file("arithmetic", public_inputs, private_inputs, vec![], backend)?;
+    test_file("arithmetic", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -267,6 +282,7 @@ fn test_public_output(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec!["8"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -285,6 +301,7 @@ fn test_lc_return(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec!["2"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -305,7 +322,7 @@ fn test_poseidon(#[case] backend: BackendKind) -> miette::Result<()> {
 
     let public_inputs = &format!(r#"{{"public_input": "{digest_dec}"}}"#);
 
-    test_file("poseidon", public_inputs, private_inputs, vec![], backend)?;
+    test_file("poseidon", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -317,7 +334,7 @@ fn test_bool(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": false}"#;
     let public_inputs = r#"{"public_input": true}"#;
 
-    test_file("bool", public_inputs, private_inputs, vec![], backend)?;
+    test_file("bool", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -329,7 +346,7 @@ fn test_mutable(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"xx": "2", "yy": "3"}"#;
     let public_inputs = r#"{}"#;
 
-    test_file("mutable", public_inputs, private_inputs, vec![], backend)?;
+    test_file("mutable", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -341,7 +358,7 @@ fn test_for_loop(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": ["2", "3", "4"]}"#;
     let public_inputs = r#"{"public_input": "9"}"#;
 
-    test_file("for_loop", public_inputs, private_inputs, vec![], backend)?;
+    test_file("for_loop", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -353,7 +370,7 @@ fn test_dup_var(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"private_input": ["1", "2", "2"]}"#;
     let public_inputs = r#"{"public_input": "10"}"#;
 
-    test_file("dup_var", public_inputs, private_inputs, vec![], backend)?;
+    test_file("dup_var", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -365,7 +382,7 @@ fn test_array(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"public_input": ["1", "2"]}"#;
 
-    test_file("array", public_inputs, private_inputs, vec![], backend)?;
+    test_file("array", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -377,7 +394,7 @@ fn test_equals(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": ["3", "3"]}"#;
 
-    test_file("equals", public_inputs, private_inputs, vec![], backend)?;
+    test_file("equals", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -389,7 +406,7 @@ fn test_not_equal(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": ["1", "2"]}"#;
 
-    test_file("not_equal", public_inputs, private_inputs, vec![], backend)?;
+    test_file("not_equal", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -401,7 +418,7 @@ fn test_types(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1", "yy": "2"}"#;
 
-    test_file("types", public_inputs, private_inputs, vec![], backend)?;
+    test_file("types", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -420,6 +437,7 @@ fn test_const(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         expected_public_output,
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -432,7 +450,7 @@ fn test_functions(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"one": "1"}"#;
 
-    test_file("functions", public_inputs, private_inputs, vec![], backend)?;
+    test_file("functions", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -444,7 +462,7 @@ fn test_methods(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1"}"#;
 
-    test_file("methods", public_inputs, private_inputs, vec![], backend)?;
+    test_file("methods", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -462,6 +480,7 @@ fn test_types_array(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -481,6 +500,7 @@ fn test_iterate(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         expected_public_output,
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -493,7 +513,7 @@ fn test_assignment(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "2"}"#;
 
-    test_file("assignment", public_inputs, private_inputs, vec![], backend)?;
+    test_file("assignment", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -524,7 +544,7 @@ fn test_if_else(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"xx": "1"}"#;
 
-    test_file("if_else", public_inputs, private_inputs, vec![], backend)?;
+    test_file("if_else", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -536,7 +556,7 @@ fn test_sudoku(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{"solution": { "inner": ["9", "5", "3", "6", "2", "1", "7", "8", "4", "1", "4", "8", "7", "5", "9", "2", "6", "3", "2", "7", "6", "8", "3", "4", "9", "5", "1", "3", "6", "9", "2", "7", "5", "4", "1", "8", "4", "8", "5", "9", "1", "6", "3", "7", "2", "7", "1", "2", "3", "4", "8", "6", "9", "5", "6", "3", "7", "1", "8", "2", "5", "4", "9", "5", "2", "1", "4", "9", "7", "8", "3", "6", "8", "9", "4", "5", "6", "3", "1", "2", "7"] }}"#;
     let public_inputs = r#"{"grid": { "inner": ["0", "5", "3", "6", "2", "1", "7", "8", "4", "0", "4", "8", "7", "5", "9", "2", "6", "3", "2", "7", "6", "8", "3", "4", "9", "5", "1", "3", "6", "9", "2", "7", "0", "4", "1", "8", "4", "8", "5", "9", "1", "6", "3", "7", "2", "0", "1", "2", "3", "4", "8", "6", "9", "5", "6", "3", "0", "1", "8", "2", "5", "4", "9", "5", "2", "1", "4", "9", "0", "8", "3", "6", "8", "9", "4", "5", "6", "3", "1", "2", "7"] }}"#;
 
-    test_file("sudoku", public_inputs, private_inputs, vec![], backend)?;
+    test_file("sudoku", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -548,7 +568,7 @@ fn test_literals(#[case] backend: BackendKind) -> miette::Result<()> {
     let private_inputs = r#"{}"#;
     let public_inputs = r#"{"public_input": "42"}"#;
 
-    test_file("literals", public_inputs, private_inputs, vec![], backend)?;
+    test_file("literals", public_inputs, private_inputs, vec![], backend, DEFAULT_OPTIONS)?;
 
     Ok(())
 }
@@ -566,6 +586,7 @@ fn test_public_output_array(#[case] backend: BackendKind) -> miette::Result<()> 
         private_inputs,
         vec!["8", "2"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -584,6 +605,7 @@ fn test_types_array_output(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec!["2", "4", "1", "8"], // 2x, y, x, 2y
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -602,6 +624,7 @@ fn test_public_output_bool(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec!["1"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -620,6 +643,7 @@ fn test_public_output_types(#[case] backend: BackendKind) -> miette::Result<()> 
         private_inputs,
         vec!["1", "2"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -638,6 +662,7 @@ fn test_generic_repeated_array(#[case] backend: BackendKind) -> miette::Result<(
         private_inputs,
         vec!["1", "1", "1"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -656,6 +681,7 @@ fn test_generic_array_access(#[case] backend: BackendKind) -> miette::Result<()>
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -674,6 +700,7 @@ fn test_generic_array_nested(#[case] backend: BackendKind) -> miette::Result<()>
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -692,6 +719,7 @@ fn test_generic_fn_multi_init(#[case] backend: BackendKind) -> miette::Result<()
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -710,6 +738,7 @@ fn generic_method_multi_init(#[case] backend: BackendKind) -> miette::Result<()>
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -728,6 +757,7 @@ fn test_generic_for_loop(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -746,6 +776,7 @@ fn test_generic_builtin_bits(#[case] backend: BackendKind) -> miette::Result<()>
         private_inputs,
         vec![],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -764,6 +795,7 @@ fn test_generic_iterator(#[case] backend: BackendKind) -> miette::Result<()> {
         private_inputs,
         vec!["1"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -782,6 +814,7 @@ fn test_generic_nested_func(#[case] backend: BackendKind) -> miette::Result<()> 
         private_inputs,
         vec!["1", "1", "1"],
         backend,
+        DEFAULT_OPTIONS,
     )?;
 
     Ok(())
@@ -800,7 +833,8 @@ fn test_generic_nested_method(#[case] backend: BackendKind) -> miette::Result<()
         private_inputs,
         vec!["1", "1", "1"],
         backend,
-    )?;
+        DEFAULT_OPTIONS,
+        )?;
 
     Ok(())
 }
@@ -813,7 +847,19 @@ fn test_hint_fn(#[case] backend: BackendKind) -> miette::Result<()> {
     let public_inputs = r#"{"public_input": "2"}"#;
     let private_inputs = r#"{"private_input": "2"}"#;
 
-    test_file("hint", public_inputs, private_inputs, vec!["8"], backend)?;
+    test_file("hint", public_inputs, private_inputs, vec!["8"], backend, DEFAULT_OPTIONS)?;
+
+    Ok(())
+}
+
+#[rstest]
+#[case::kimchi_vesta(BackendKind::KimchiVesta(KimchiVesta::new(false)))]
+#[case::r1cs_bls(BackendKind::R1csBls12_381(R1CS::new()))]
+fn test_unused_variables_with_disabled_safety_check(#[case] backend: BackendKind) -> miette::Result<()> {
+    let public_inputs = r#"{"xx": "2"}"#;
+    let private_inputs = r#"{"yy": "1"}"#;
+
+    test_file("unused_variables", public_inputs, private_inputs, vec![], backend, DISABLE_SAFETY_CHECK_OPTIONS)?;
 
     Ok(())
 }

--- a/src/tests/modules.rs
+++ b/src/tests/modules.rs
@@ -124,7 +124,7 @@ fn test_simple_module() -> miette::Result<()> {
     let kimchi_vesta = KimchiVesta::new(false);
 
     // compile
-    compile(&sources, tast, kimchi_vesta, &mut None)?;
+    compile(&sources, tast, kimchi_vesta, &mut None, false)?;
 
     Ok(())
 }

--- a/src/tests/stdlib/mod.rs
+++ b/src/tests/stdlib/mod.rs
@@ -80,7 +80,7 @@ fn test_stdlib_code(
     .unwrap();
 
     let mast = mast::monomorphize(tast)?;
-    let compiled_circuit = CircuitWriter::generate_circuit(mast, r1cs)?;
+    let compiled_circuit = CircuitWriter::generate_circuit(mast, r1cs, false)?;
 
     // this should check the constraints
     let generated_witness = compiled_circuit.generate_witness(


### PR DESCRIPTION
This option allows variables that are not constrained.

Right now, it's a bit ugly how this parameter has to be passed. I will explain the workflow below, but I guess in the future, we can have a struct to capture parameters and pass them around so we can have access to user-defined configs. 

We need to add some ifs for this particular feature when we validate that variables have been used. This is happening in the `finalize_circuit` function inside circuit_writer instead of in the type checking and semantic checks. To pass the parameter from the UI based on which we are going to return an error or not, we do the following:

1. Add the option to `cli/cmd_build_and_check.rs` and `cli/cmd_prove_and_verify.rs`
2. Add bool parameter (`disable_safety_check`) in `compiler.rs::compile` function
3. Pass that parameter to `CircuitWriter::generate_circuit` function
4. Pass that parameter to `finalize_circuit` function (In all backends)
5. Add the if statements (In all backends)

Furthermore, in the tests, we always set that option to false.