### PR TITLE
Improve error when a keyword is used as identifier

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub enum ErrorKind {
     #[error("invalid token, expected: {0}")]
     ExpectedToken(TokenKind),
 
+    #[error("invalid token, unexpected keyword: {0}, expected: {1}")]
+    ExpectedTokenNotKeyword(String, TokenKind),
+
     #[error("invalid path: {0}")]
     InvalidPath(&'static str),
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -238,4 +238,20 @@ mod tests {
         let parsed = Stmt::parse(ctx, tokens).unwrap();
         println!("{:?}", parsed);
     }
+
+    #[test]
+    fn expected_token_not_keyword_as_identifier() {
+        let code = r#"Foo { pub: Field }"#;
+        let tokens = &mut Token::parse(0, code).unwrap();
+        let ctx = &mut ParserCtx::default();
+        let parsed = StructDef::parse(ctx, tokens);
+        assert!(parsed.is_err());
+        assert!(parsed.as_ref().err().is_some());
+        match &parsed.as_ref().err().unwrap().kind {
+            ErrorKind::ExpectedTokenNotKeyword(keyword, _) => {
+                assert_eq!(keyword, "pub");
+            }
+            _ => panic!("expected error: ExpectedTokenNotKeyword"),
+        }
+    }
 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -674,6 +674,13 @@ impl Ident {
                 value: ident,
                 span: token.span,
             }),
+            TokenKind::Keyword(keyword) => Err(ctx.error(
+                ErrorKind::ExpectedTokenNotKeyword(
+                    keyword.to_string(),
+                    TokenKind::Identifier("".to_string()),
+                ),
+                token.span,
+            )),
 
             _ => Err(ctx.error(
                 ErrorKind::ExpectedToken(TokenKind::Identifier("".to_string())),


### PR DESCRIPTION
  This PR addresses this issue: https://github.com/zksecurity/noname/issues/236