### PR TITLE
support left shift or right shift operator

### DIFF
--- a/src/circuit_writer/ir.rs
+++ b/src/circuit_writer/ir.rs
@@ -1,6 +1,6 @@
 use ark_ff::Zero;
 use circ::{
-    ir::term::{leaf_term, term, BoolNaryOp, Op, PfNaryOp, PfUnOp, Sort, Term, Value},
+    ir::term::{leaf_term, term, BoolNaryOp, BvBinOp, Op, PfNaryOp, PfUnOp, Sort, Term, Value},
     term,
 };
 use num_bigint::BigUint;
@@ -893,6 +893,14 @@ impl<B: Backend> IRWriter<B> {
                     }
                     Op2::BoolOr => {
                         let t: Term = term![Op::BoolNaryOp(BoolNaryOp::Or); lhs.cvars[0].clone(), rhs.cvars[0].clone()];
+                        Var::new_cvar(t, expr.span)
+                    }
+                    Op2::RightShift => {
+                        let t: Term = term![Op::BvBinOp(BvBinOp::Lshr); lhs.cvars[0].clone(), rhs.cvars[0].clone()];
+                        Var::new_cvar(t, expr.span)
+                    }
+                    Op2::LeftShift => {
+                        let t: Term = term![Op::BvBinOp(BvBinOp::Shl); lhs.cvars[0].clone(), rhs.cvars[0].clone()];
                         Var::new_cvar(t, expr.span)
                     }
                     Op2::Division => {

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -654,6 +654,8 @@ impl<B: Backend> CircuitWriter<B> {
                     Op2::Inequality => field::not_equal(self, &lhs, &rhs, expr.span),
                     Op2::BoolAnd => boolean::and(self, &lhs[0], &rhs[0], expr.span),
                     Op2::BoolOr => boolean::or(self, &lhs[0], &rhs[0], expr.span),
+                    Op2::LeftShift => field::shift_left(self, &lhs[0], &rhs[0], expr.span),
+                    Op2::RightShift => field::shift_right(self, &lhs[0], &rhs[0], expr.span),
                     Op2::Division => todo!(),
                 };
 

--- a/src/constraints/field.rs
+++ b/src/constraints/field.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::boolean;
 
-use ark_ff::{One, Field,  PrimeField, Zero};
+use ark_ff::{Field, One, PrimeField, Zero};
 
 use std::ops::Neg;
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -157,6 +157,8 @@ pub enum TokenKind {
     Pipe,               // |
     DoublePipe,         // ||
     Exclamation,        // !
+    DoubleGreater,      // >>
+    DoubleLess,         // <<
     Question,           // ?
     PlusEqual,          // +=
     MinusEqual,         // -=
@@ -201,6 +203,8 @@ impl Display for TokenKind {
             Pipe => "`|`",
             DoublePipe => "`||`",
             Exclamation => "`!`",
+            DoubleGreater => "`>>`",
+            DoubleLess => "`<<`",
             Question => "`?`",
             PlusEqual => "`+=`",
             MinusEqual => "`-=`",
@@ -378,10 +382,22 @@ impl Token {
                     }
                 }
                 '>' => {
-                    tokens.push(TokenKind::Greater.new_token(ctx, 1));
+                    let next_c = chars.peek();
+                    if matches!(next_c, Some(&'>')) {
+                        tokens.push(TokenKind::DoubleGreater.new_token(ctx, 2));
+                        chars.next();
+                    } else {
+                        tokens.push(TokenKind::Greater.new_token(ctx, 1));
+                    }
                 }
                 '<' => {
-                    tokens.push(TokenKind::Less.new_token(ctx, 1));
+                    let next_c = chars.peek();
+                    if matches!(next_c, Some(&'<')) {
+                        tokens.push(TokenKind::DoubleLess.new_token(ctx, 2));
+                        chars.next();
+                    } else {
+                        tokens.push(TokenKind::Less.new_token(ctx, 1));
+                    }
                 }
                 '=' => {
                     let next_c = chars.peek();

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -801,7 +801,9 @@ fn monomorphize_expr<B: Backend>(
                 | Op2::Multiplication
                 | Op2::Division
                 | Op2::BoolAnd
-                | Op2::BoolOr => lhs_mono.typ,
+                | Op2::BoolOr
+                | Op2::RightShift
+                | Op2::LeftShift => lhs_mono.typ,
             };
 
             let ExprMonoInfo { expr: lhs_expr, .. } = lhs_mono;

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -134,6 +134,8 @@ pub enum Op2 {
     Inequality,
     BoolAnd,
     BoolOr,
+    RightShift,
+    LeftShift,
 }
 
 impl Expr {
@@ -512,7 +514,9 @@ impl Expr {
                     | TokenKind::NotEqual
                     | TokenKind::DoubleAmpersand
                     | TokenKind::DoublePipe
-                    | TokenKind::Exclamation,
+                    | TokenKind::Exclamation
+                    | TokenKind::DoubleGreater
+                    | TokenKind::DoubleLess,
                 ..
             }) => {
                 // lhs + rhs
@@ -526,6 +530,8 @@ impl Expr {
                     TokenKind::NotEqual => Op2::Inequality,
                     TokenKind::DoubleAmpersand => Op2::BoolAnd,
                     TokenKind::DoublePipe => Op2::BoolOr,
+                    TokenKind::DoubleGreater => Op2::RightShift,
+                    TokenKind::DoubleLess => Op2::LeftShift,
                     _ => unreachable!(),
                 };
 

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -388,7 +388,9 @@ impl<B: Backend> TypeChecker<B> {
                     | Op2::Multiplication
                     | Op2::Division
                     | Op2::BoolAnd
-                    | Op2::BoolOr => lhs_node.typ,
+                    | Op2::BoolOr
+                    | Op2::RightShift
+                    | Op2::LeftShift => lhs_node.typ,
                 };
 
                 Some(ExprTyInfo::new_anon(typ))


### PR DESCRIPTION
Resolves #181 

To implement right-shift and left-shift operators, here are the changes I've made:

- Added token recognition for `<<` and `>>` in the lexer
- Extended `Op2` enum to include `RightShift` and `LeftShift`
- Updated the parser to recognize and handle bit shift tokens
- Modified type checker to support the shift operations
- Implemented circuit writer logic for bit shifts using field arithmetic
- Implemented bit shift operations for field elements, supporting constant value shifts and cell variable shifts with constant shift amounts
- Added bitwise shift operations using logical shift right (Lshr) and shift left (Shl) in circuit IR generation
