### PR TITLE
Fix typos

### DIFF
--- a/book/src/cellvar.md
+++ b/book/src/cellvar.md
@@ -55,7 +55,7 @@ Note: a `CellVar` is potentially not directly added to the rows of the execution
 For example, a private input is converted directly to a (number of) `CellVar`(s), 
 but only added to the rows when it appears in a constraint for the first time.
 
-As the final step of the compilation, we double check that all `CellVar`s have appeared in the rows of the execution trace at some point. If they haven't, it can mean two things:
+As the final step of the compilation, we double-check that all `CellVar`s have appeared in the rows of the execution trace at some point. If they haven't, it can mean two things:
 
 * A private or public input was never used in the circuit. In this case we return an error to the user.
 * There is a bug in the compiler. In this case we panic.

--- a/book/src/expressions.md
+++ b/book/src/expressions.md
@@ -38,7 +38,7 @@ In the example
 let a = b.c.d;
 ```
 
-the expression node representing the right hand side could be seen as:
+the expression node representing the right-hand side could be seen as:
 
 ```rust
 ExprKind::FieldAccess {

--- a/book/src/expressions.md
+++ b/book/src/expressions.md
@@ -64,7 +64,7 @@ At some point the [circuit-writer]() would have to go through an expression node
 
 ```rust
 ExprKind::Assignment {
-    lhs: /* the left hand side as an Expr */,
+    lhs: /* the left-hand side as an Expr */,
     rhs: Expr { kind: ExprKind::BigInt { value: 42 } },
 }
 ```

--- a/book/src/methods.md
+++ b/book/src/methods.md
@@ -47,7 +47,7 @@ This still doesn't fix our problem. In the line:
 let thing = Thing { x: 1, y: 2 };
 ```
 
-the local variable `thing` is stored, but the right hand side is computed via the `compute_expr()` function which will go through the AST and potentially create different anonymous variables until it can compute a value.
+the local variable `thing` is stored, but the right-hand side is computed via the `compute_expr()` function which will go through the AST and potentially create different anonymous variables until it can compute a value.
 
 There's three ways to solve this:
 

--- a/book/src/paths.md
+++ b/book/src/paths.md
@@ -20,7 +20,7 @@ A path is represent like this internally:
 /// `module::A.a`.
 #[derive(Debug, Clone)]
 pub struct Path {
-    /// A module, if this is an foreign import.
+    /// A module, if this is a foreign import.
     pub module: Option<Ident>,
 
     /// The name of the type, function, method, or constant.


### PR DESCRIPTION
This pull request addresses several minor typos and grammatical corrections in the following markdown files: `cellvar.md`, `expressions.md`, `methods.md`, and `paths.md`. Changes include:

- Adding hyphens to compound adjectives (e.g., "right-hand side" and "left-hand side").
- Correcting the spelling of "double-check" to include the hyphen.
- Replacing "an" with "a" where the following word does not start with a vowel sound (e.g., "a foreign import").
  
These changes improve clarity and ensure consistency in the documentation.
