### PR TITLE
Upgrade to arkworks 0.4.0/2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -637,15 +637,6 @@ source = "git+https://github.com/iden3/circom.git?tag=v2.1.8#f0deda416abe91e5dd9
 dependencies = [
  "circom_algebra",
  "json",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -719,7 +710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -730,7 +721,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -815,7 +806,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -850,7 +841,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -989,7 +980,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1094,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "groupmap"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1115,12 +1106,6 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1297,19 +1282,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
 [[package]]
 name = "internal-tracing"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 
 [[package]]
 name = "is-terminal"
@@ -1376,7 +1361,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 [[package]]
 name = "kimchi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1403,7 +1388,6 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_with",
- "snarky-deriver",
  "strum",
  "strum_macros",
  "thiserror",
@@ -1530,7 +1514,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1552,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1562,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "mina-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1628,6 +1612,7 @@ dependencies = [
  "num-bigint-dig",
  "num-traits",
  "once_cell",
+ "rand 0.8.5",
  "regex",
  "rmp-serde",
  "rstest",
@@ -1708,7 +1693,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1743,8 +1728,9 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
+ "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
@@ -1756,6 +1742,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
+ "rmp-serde",
+ "secp256k1",
  "serde",
  "serde_with",
  "sha2",
@@ -1839,7 +1827,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "poly-commitment"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1875,18 +1863,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2019,25 +2007,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2048,9 +2036,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -2105,7 +2093,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.90",
  "unicode-ident",
 ]
 
@@ -2130,9 +2118,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -2154,6 +2142,24 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "semver"
@@ -2178,7 +2184,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2204,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2233,7 +2239,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2250,7 +2256,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2314,18 +2320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
-name = "snarky-deriver"
-version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
-dependencies = [
- "convert_case",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,7 +2357,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2413,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2478,7 +2472,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2548,7 +2542,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2578,20 +2572,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2700,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "turshi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
 dependencies = [
  "ark-ff",
  "hex",
@@ -2721,21 +2715,15 @@ checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -2794,7 +2782,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -2816,7 +2804,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2933,9 +2921,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -2966,7 +2954,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2986,5 +2974,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.90",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "groupmap"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "internal-tracing"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 
 [[package]]
 name = "is-terminal"
@@ -1361,7 +1361,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 [[package]]
 name = "kimchi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "mina-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1827,7 +1827,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "poly-commitment"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2694,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "turshi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems#6c674bdda34ab6db2b74984b0eb12f7fa1733e8c"
+source = "git+https://github.com/o1-labs/proof-systems?rev=5b4ac1437e7912237be88d97b4b4891b22e3e61f#5b4ac1437e7912237be88d97b4b4891b22e3e61f"
 dependencies = [
  "ark-ff",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,13 +30,14 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "getrandom 0.2.15",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -120,20 +121,21 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65be532f9dd1e98ad0150b037276cde464c6f371059e6dd02c0222395761f6aa"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-serialize",
  "ark-std",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -142,14 +144,17 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff",
+ "ark-poly",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
  "num-traits",
  "rayon",
  "zeroize",
@@ -157,28 +162,30 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "digest",
+ "itertools 0.10.5",
  "num-bigint 0.4.5",
  "num-traits",
  "paste",
  "rayon",
- "rustc_version 0.3.3",
+ "rustc_version",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -186,35 +193,36 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.5",
  "num-traits",
+ "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "ark-poly"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
  "ark-ff",
  "ark-serialize",
  "ark-std",
  "derivative",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
  "rayon",
 ]
 
 [[package]]
 name = "ark-relations"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
+checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
  "ark-ff",
  "ark-std",
@@ -223,20 +231,21 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.9.0",
+ "digest",
+ "num-bigint 0.4.5",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -245,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -432,7 +441,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -504,7 +513,7 @@ dependencies = [
  "circ_waksman",
  "fxhash",
  "im",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "logos",
  "once_cell",
@@ -589,7 +598,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -598,7 +607,7 @@ version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -628,6 +637,15 @@ source = "git+https://github.com/iden3/circom.git?tag=v2.1.8#f0deda416abe91e5dd9
 dependencies = [
  "circom_algebra",
  "json",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -682,36 +700,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.9",
- "darling_macro 0.20.9",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -724,19 +718,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.66",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -745,7 +728,7 @@ version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.9",
+ "darling_core",
  "quote",
  "syn 2.0.66",
 ]
@@ -794,15 +777,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
@@ -831,12 +805,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "disjoint-set"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
 
 [[package]]
 name = "educe"
@@ -1126,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "groupmap"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1135,18 +1103,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1164,12 +1132,6 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1347,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "internal-tracing"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 
 [[package]]
 name = "is-terminal"
@@ -1382,6 +1344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,18 +1376,18 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 [[package]]
 name = "kimchi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "blake2",
- "disjoint-set",
  "groupmap",
  "hex",
  "internal-tracing",
- "itertools",
+ "itertools 0.12.1",
+ "log",
  "mina-curves",
  "mina-poseidon",
  "num-bigint 0.4.5",
@@ -1431,7 +1402,8 @@ dependencies = [
  "rayon",
  "rmp-serde",
  "serde",
- "serde_with 1.14.0",
+ "serde_with",
+ "snarky-deriver",
  "strum",
  "strum_macros",
  "thiserror",
@@ -1580,27 +1552,29 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "num-bigint 0.4.5",
 ]
 
 [[package]]
 name = "mina-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
+ "ark-serialize",
  "mina-curves",
  "o1-utils",
  "once_cell",
  "rand 0.8.5",
  "rayon",
  "serde",
- "serde_with 1.14.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -1647,7 +1621,7 @@ dependencies = [
  "fs_extra",
  "fxhash",
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "kimchi",
  "miette",
  "num-bigint 0.4.5",
@@ -1660,7 +1634,7 @@ dependencies = [
  "rug",
  "serde",
  "serde_json",
- "serde_with 3.11.0",
+ "serde_with",
  "thiserror",
  "tokio",
  "toml",
@@ -1728,13 +1702,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1769,9 +1743,8 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
- "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
@@ -1784,7 +1757,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "serde_with 1.14.0",
+ "serde_with",
  "sha2",
  "thiserror",
 ]
@@ -1852,17 +1825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,7 +1839,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "poly-commitment"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1885,7 +1847,7 @@ dependencies = [
  "ark-serialize",
  "blake2",
  "groupmap",
- "itertools",
+ "itertools 0.12.1",
  "mina-curves",
  "mina-poseidon",
  "o1-utils",
@@ -1895,7 +1857,7 @@ dependencies = [
  "rayon",
  "rmp-serde",
  "serde",
- "serde_with 1.14.0",
+ "serde_with",
  "thiserror",
 ]
 
@@ -2127,7 +2089,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2142,7 +2104,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 2.0.66",
  "unicode-ident",
 ]
@@ -2168,20 +2130,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.23",
+ "semver",
 ]
 
 [[package]]
@@ -2204,27 +2157,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -2290,16 +2225,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
@@ -2312,20 +2237,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.11.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2334,7 +2247,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
- "darling 0.20.9",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -2348,7 +2261,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2401,6 +2314,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "snarky-deriver"
+version = "0.1.0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
+dependencies = [
+ "convert_case",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,33 +2343,27 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2781,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "turshi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=a5d8883ddf649c22f38aaac122d368ecb9fa2230#a5d8883ddf649c22f38aaac122d368ecb9fa2230"
+source = "git+https://github.com/o1-labs/proof-systems?rev=483bd5bd918ebbc1d5e008ce892d7a0023b50ed1#483bd5bd918ebbc1d5e008ce892d7a0023b50ed1"
 dependencies = [
  "ark-ff",
  "hex",
@@ -2793,12 +2712,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -2817,6 +2730,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3028,6 +2947,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ camino = "1.1.1" # to replace Path and PathBuf
 clap = { version = "4.0.5", features = ["derive"] } # CLI library
 dirs = "4.0.0" # helper functions (e.g. getting the home directory)
 itertools = "0.10.3" # useful iter traits
-kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "483bd5bd918ebbc1d5e008ce892d7a0023b50ed1" } # ZKP
+kimchi = { git = "https://github.com/o1-labs/proof-systems"} # ZKP
 miette = { version = "5.0.0", features = ["fancy"] }                                 # nice errors
 num-traits = "0.2.15"                                                                # useful traits on big ints
 once_cell = "1.15.0"                                                                 # for lazy statics
@@ -45,6 +45,7 @@ thiserror = "1.0.31"                                                            
 toml = "0.8.8"                                                                       # to parse manifest files
 constraint_writers = { git = "https://github.com/iden3/circom.git", tag = "v2.1.8" } # to generate r1cs file
 num-bigint-dig = "0.6.0"                                                             # to adapt for circom lib
+rand = "0.8.5"
 rstest = "0.19.0"                                                                    # for testing different backend cases
 rug = "1.26.1"                                                                       # circ uses this for integer type
 circ = { git = "https://github.com/circify/circ", rev = "8140b1369edd5992ede038d2e9e5721510ae7065" }                                # for compiling to circ IR

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ camino = "1.1.1" # to replace Path and PathBuf
 clap = { version = "4.0.5", features = ["derive"] } # CLI library
 dirs = "4.0.0" # helper functions (e.g. getting the home directory)
 itertools = "0.10.3" # useful iter traits
-kimchi = { git = "https://github.com/o1-labs/proof-systems"} # ZKP
+kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "5b4ac1437e7912237be88d97b4b4891b22e3e61f" } # ZKP
 miette = { version = "5.0.0", features = ["fancy"] }                                 # nice errors
 num-traits = "0.2.15"                                                                # useful traits on big ints
 once_cell = "1.15.0"                                                                 # for lazy statics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ fs_extra = "1.3.0"
 dirs = "4.0"
 
 [dependencies]
-ark-ec = "0.3.0" # elliptic curve library
-ark-ff = "0.3.0"
-ark-bls12-381 = "0.3.0" # bls12-381 curve for r1cs backend
-ark-relations = "0.3.0"
-ark-bn254 = "0.3.0" # bn128 curve for r1cs backend
-ark-serialize = "0.3.0" # serialization of arkworks types
+ark-ec = "0.4.2" # elliptic curve library
+ark-ff = "0.4.2"
+ark-bls12-381 = "0.4.0" # bls12-381 curve for r1cs backend
+ark-relations = "0.4.0"
+ark-bn254 = "0.4.0" # bn128 curve for r1cs backend
+ark-serialize = "0.4.2" # serialization of arkworks types
 axum = { version = "0.7.7", features = ["macros"] } # web server
 base64 = "0.22.1" # for base64 encoding
 educe = { version = "0.6", default-features = false, features = [
@@ -32,8 +32,7 @@ camino = "1.1.1" # to replace Path and PathBuf
 clap = { version = "4.0.5", features = ["derive"] } # CLI library
 dirs = "4.0.0" # helper functions (e.g. getting the home directory)
 itertools = "0.10.3" # useful iter traits
-kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "a5d8883ddf649c22f38aaac122d368ecb9fa2230" } # ZKP - Dec 5th, 2023 revision
-#kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "b9589626f834f9dbf9d587e73fd8176171231e90" } # ZKP
+kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "483bd5bd918ebbc1d5e008ce892d7a0023b50ed1" } # ZKP
 miette = { version = "5.0.0", features = ["fancy"] }                                 # nice errors
 num-traits = "0.2.15"                                                                # useful traits on big ints
 once_cell = "1.15.0"                                                                 # for lazy statics

--- a/src/backends/kimchi/prover.rs
+++ b/src/backends/kimchi/prover.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 
 use itertools::chain;
-use kimchi::{mina_curves::pasta::{Vesta, VestaParameters}, poly_commitment::SRS as _};
 use kimchi::mina_poseidon::constants::PlonkSpongeConstantsKimchi;
 use kimchi::mina_poseidon::sponge::{DefaultFqSponge, DefaultFrSponge};
 use kimchi::poly_commitment::commitment::CommitmentCurve;
@@ -20,6 +19,10 @@ use kimchi::proof::ProverProof;
 use kimchi::{
     circuits::constraints::ConstraintSystem, groupmap::GroupMap, mina_curves::pasta::Pallas,
     poly_commitment::ipa::SRS,
+};
+use kimchi::{
+    mina_curves::pasta::{Vesta, VestaParameters},
+    poly_commitment::SRS as _,
 };
 
 use miette::{Context, IntoDiagnostic};
@@ -107,7 +110,7 @@ impl KimchiVesta {
             .wrap_err("kimchi: could not create a constraint system with the given circuit and public input size")?;
 
         // create SRS (for vesta, as the circuit is in Fp)
-        let mut srs = SRS::<Curve>::create(cs.domain.d1.size as usize);
+        let srs = SRS::<Curve>::create(cs.domain.d1.size as usize);
         srs.get_lagrange_basis(cs.domain.d1);
         let srs = std::sync::Arc::new(srs);
 
@@ -198,12 +201,15 @@ impl ProverIndex {
         }
 
         // create proof
-        let proof =
-            ProverProof::create::<BaseSponge, ScalarSponge, _>(&GROUP_MAP, witness, &[], &self.index, &mut rand::rngs::OsRng)
-                //.map_err(|e| miette!(e))
-                .into_diagnostic()
-                .wrap_err("kimchi: could not create a proof with the given inputs")?;
-
+        let proof = ProverProof::create::<BaseSponge, ScalarSponge, _>(
+            &GROUP_MAP,
+            witness,
+            &[],
+            &self.index,
+            &mut rand::rngs::OsRng,
+        )
+        .into_diagnostic()
+        .wrap_err("kimchi: could not create a proof with the given inputs")?;
 
         // return proof + public output
         Ok((

--- a/src/backends/r1cs/mod.rs
+++ b/src/backends/r1cs/mod.rs
@@ -4,7 +4,6 @@ pub mod snarkjs;
 
 use std::collections::{HashMap, HashSet};
 
-use ark_ff::FpParameters;
 use circ::cfg::{CircCfg, CircOpt};
 use circ_fields::FieldV;
 use itertools::{izip, Itertools as _};
@@ -303,7 +302,7 @@ where
 
     /// Returns the prime for snarkjs based on the curve field.
     fn prime(&self) -> BigUint {
-        F::Params::MODULUS.into()
+        F::MODULUS.into()
     }
 
     /// Add an r1cs constraint that is 3 linear combinations.

--- a/src/backends/r1cs/snarkjs.rs
+++ b/src/backends/r1cs/snarkjs.rs
@@ -1,4 +1,5 @@
 use crate::backends::BackendField;
+use ark_ff::BigInteger;
 use constraint_writers::r1cs_writer::{ConstraintSection, HeaderData, R1CSWriter};
 use miette::Diagnostic;
 use thiserror::Error;
@@ -191,7 +192,7 @@ where
     fn convert_to_bigint(value: &F) -> BigInt {
         BigInt::from_bytes_le(
             num_bigint_dig::Sign::Plus,
-            &ark_ff::BigInteger::to_bytes_le(&value.into_repr()),
+            &value.into_bigint().to_bytes_le(),
         )
     }
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, fs::File, io::Read, str::FromStr};
 
 use ark_ff::{One, Zero};
+use kimchi::o1_utils::FieldHelpers;
 use miette::Diagnostic;
 use num_bigint::BigUint;
 use thiserror::Error;
-use kimchi::o1_utils::FieldHelpers;
 
 use crate::{
     backends::{kimchi::VestaField, Backend},

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, fs::File, io::Read, str::FromStr};
 
-use ark_ff::{One, PrimeField, Zero};
+use ark_ff::{One, Zero};
 use miette::Diagnostic;
 use num_bigint::BigUint;
 use thiserror::Error;
@@ -170,7 +170,7 @@ pub trait ExtField /* : PrimeField*/ {
 
 impl ExtField for VestaField {
     fn to_dec_string(&self) -> String {
-        let biguint: BigUint = self.into_repr().into();
+        let biguint: BigUint = self.0.into();
         biguint.to_str_radix(10)
     }
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -6,6 +6,7 @@ use ark_ff::{One, Zero};
 use miette::Diagnostic;
 use num_bigint::BigUint;
 use thiserror::Error;
+use kimchi::o1_utils::FieldHelpers;
 
 use crate::{
     backends::{kimchi::VestaField, Backend},
@@ -170,7 +171,7 @@ pub trait ExtField /* : PrimeField*/ {
 
 impl ExtField for VestaField {
     fn to_dec_string(&self) -> String {
-        let biguint: BigUint = self.0.into();
+        let biguint: BigUint = self.to_biguint();
         biguint.to_str_radix(10)
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,7 +1,7 @@
 //! This adds a few utility functions for serializing and deserializing
 //! [arkworks](http://arkworks.rs/) types that implement [CanonicalSerialize] and [CanonicalDeserialize].
 
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 use serde_with::Bytes;
 
 //
@@ -14,6 +14,7 @@ pub mod ser {
     //! `#[serde(with = "o1_utils::serialization::ser") attribute"]`
 
     use super::*;
+    use ark_serialize::{Compress, Validate};
     use serde_with::{DeserializeAs, SerializeAs};
 
     /// You can use this to serialize an arkworks type with serde and the "serialize_with" attribute.
@@ -23,7 +24,7 @@ pub mod ser {
         S: serde::Serializer,
     {
         let mut bytes = vec![];
-        val.serialize(&mut bytes)
+        val.serialize_with_mode(&mut bytes, Compress::Yes)
             .map_err(serde::ser::Error::custom)?;
 
         Bytes::serialize_as(&bytes, serializer)
@@ -37,7 +38,7 @@ pub mod ser {
         D: serde::Deserializer<'de>,
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
-        T::deserialize(&mut &bytes[..]).map_err(serde::de::Error::custom)
+        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -60,7 +61,7 @@ where
         S: serde::Serializer,
     {
         let mut bytes = vec![];
-        val.serialize(&mut bytes)
+        val.serialize_with_mode(&mut bytes, Compress::Yes)
             .map_err(serde::ser::Error::custom)?;
 
         Bytes::serialize_as(&bytes, serializer)
@@ -76,6 +77,6 @@ where
         D: serde::Deserializer<'de>,
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
-        T::deserialize(&mut &bytes[..]).map_err(serde::de::Error::custom)
+        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes).map_err(serde::de::Error::custom)
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -38,7 +38,8 @@ pub mod ser {
         D: serde::Deserializer<'de>,
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
-        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes).map_err(serde::de::Error::custom)
+        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -77,6 +78,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
-        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes).map_err(serde::de::Error::custom)
+        T::deserialize_with_mode(&mut &bytes[..], Compress::Yes, Validate::Yes)
+            .map_err(serde::de::Error::custom)
     }
 }

--- a/src/stdlib/bits.rs
+++ b/src/stdlib/bits.rs
@@ -81,7 +81,7 @@ fn check_field_size<B: Backend>(
     span: Span,
 ) -> Result<Option<Var<B::Field, B::Var>>> {
     let var = &vars[0].var[0];
-    let bit_len = B::Field::size_in_bits() as u64;
+    let bit_len = B::Field::MODULUS_BIT_SIZE as u64;
 
     match var {
         ConstOrCell::Const(cst) => {


### PR DESCRIPTION
Kimchi was upgraded to a newer version that uses Arkworks 0.4, and Arkworks dependencies were upgraded to match those used by Kimchi (either 0.4.0 or 0.4.2 depending).