### PR TITLE
fix: invalid folded mutable constant value

### DIFF
--- a/src/negative_tests.rs
+++ b/src/negative_tests.rs
@@ -473,6 +473,29 @@ fn test_generic_custom_type_mismatched() {
 }
 
 #[test]
+fn test_generic_mutated_cst_var_in_loop() {
+    let code = r#"
+        fn gen(const LEN: Field) -> [Field; LEN] {
+            return [0; LEN];
+        }
+        
+        fn main(pub xx: Field) {
+            let mut loopvar = 1;
+            for ii in 0..3 {
+                loopvar = loopvar + 1;
+            }
+            let arr = gen(loopvar);
+        }
+        "#;
+
+    let res = tast_pass(code).0;
+    assert!(matches!(
+        res.unwrap_err().kind,
+        ErrorKind::ArgumentTypeMismatch(..)
+    ));
+}
+
+#[test]
 fn test_array_bounds() {
     let code = r#"
         fn gen(const LEN: Field) -> [Field; LEN] {

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -261,6 +261,10 @@ impl<B: Backend> TypeChecker<B> {
                     .compute_type(lhs, typed_fn_env)?
                     .expect("type-checker bug: lhs access on an empty var");
 
+                if let Some(var_name) = &lhs_node.var_name {
+                    typed_fn_env.invalidate_cst_var(var_name);
+                }
+
                 // todo: check and update the const field type for other cases
                 // lhs can be a local variable or a path to an array
                 let lhs_name = match &lhs.kind {


### PR DESCRIPTION
When mutable constant variable is modified in a for loop, it should be marked as a non constant field. 
Otherwise the MAST phase will try to constant fold that variable into wrong constant value, because we don't support unrolling in for loop.