### PR TITLE
fix: instead of folding expr for constant values, we keep the expr as…

### DIFF
--- a/examples/functions.no
+++ b/examples/functions.no
@@ -10,6 +10,8 @@ fn main(pub one: Field) {
     let four = add(one, 3);
     assert_eq(four, 4);
 
+    // double() should not be folded to return 8
+    // the asm test will catch the missing constraint if it is folded
     let eight = double(4);
     assert_eq(eight, double(four));
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -365,4 +365,7 @@ pub enum ErrorKind {
 
     #[error("division by zero")]
     DivisionByZero,
+
+    #[error("lhs `{0}` is less than rhs `{1}`")]
+    NegativeLhsLessThanRhs(String, String),
 }

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -808,20 +808,42 @@ fn monomorphize_expr<B: Backend>(
             let ExprMonoInfo { expr: rhs_expr, .. } = rhs_mono;
 
             // fold constants
-            let cst = match (&lhs_expr.kind, &rhs_expr.kind) {
-                (ExprKind::BigUInt(lhs), ExprKind::BigUInt(rhs)) => match op {
-                    Op2::Addition => Some(lhs + rhs),
-                    Op2::Subtraction => Some(lhs - rhs),
-                    Op2::Multiplication => Some(lhs * rhs),
-                    Op2::Division => Some(lhs / rhs),
-                    _ => None,
-                },
+            let cst = match (&lhs_mono.constant, &rhs_mono.constant) {
+                (Some(PropagatedConstant::Single(lhs)), Some(PropagatedConstant::Single(rhs))) => {
+                    match op {
+                        Op2::Addition => Some(lhs + rhs),
+                        Op2::Subtraction => {
+                            if lhs < rhs {
+                                // throw error
+                                return Err(error(
+                                    ErrorKind::NegativeLhsLessThanRhs(
+                                        lhs.to_string(),
+                                        rhs.to_string(),
+                                    ),
+                                    expr.span,
+                                ));
+                            }
+                            Some(lhs - rhs)
+                        }
+                        Op2::Multiplication => Some(lhs * rhs),
+                        Op2::Division => Some(lhs / rhs),
+                        _ => None,
+                    }
+                }
                 _ => None,
             };
 
             match cst {
                 Some(v) => {
-                    let mexpr = expr.to_mast(ctx, &ExprKind::BigUInt(v.clone()));
+                    let mexpr = expr.to_mast(
+                        ctx,
+                        &ExprKind::BinaryOp {
+                            op: op.clone(),
+                            protected: *protected,
+                            lhs: Box::new(lhs_expr),
+                            rhs: Box::new(rhs_expr),
+                        },
+                    );
 
                     ExprMonoInfo::new(mexpr, typ, Some(PropagatedConstant::from(v)))
                 }


### PR DESCRIPTION
… it is