### PR TITLE
allow expressions in ifelse block

### DIFF
--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -1002,13 +1002,21 @@ fn monomorphize_expr<B: Backend>(
 
             // make sure that the type of then_ and else_ match
             if then_mono.typ != else_mono.typ {
-                Err(Error::new(
-                    "If-Else Monomorphization",
-                    ErrorKind::UnexpectedError(
-                        "`if` branch and `else` branch must have matching types",
-                    ),
-                    expr.span,
-                ))?
+                // allow fields no matter if they are constant or not
+                let both_fields = matches!(
+                    (&then_mono.typ, &else_mono.typ),
+                    (Some(TyKind::Field { .. }), Some(TyKind::Field { .. }))
+                );
+
+                if !both_fields {
+                    Err(Error::new(
+                        "If-Else Monomorphization",
+                        ErrorKind::UnexpectedError(
+                            "`if` branch and `else` branch must have matching types",
+                        ),
+                        expr.span,
+                    ))?
+                }
             }
 
             let mexpr = expr.to_mast(

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -236,23 +236,6 @@ impl Expr {
                 //           ^^^^^
                 let then_ = Box::new(Expr::parse(ctx, tokens)?);
 
-                if !matches!(
-                    &then_.kind,
-                    ExprKind::Variable { .. }
-                        | ExprKind::Bool { .. }
-                        | ExprKind::BigUInt { .. }
-                        | ExprKind::FieldAccess { .. }
-                        | ExprKind::ArrayAccess { .. }
-                ) {
-                    Err(Error::new(
-                        "parse - if keyword",
-                        ErrorKind::UnexpectedError(
-                            "_then_ branch of ternary operator cannot be more than a variable",
-                        ),
-                        span,
-                    ))?
-                }
-
                 // if cond { expr1 } else { expr2 }
                 //                 ^
                 tokens.bump_expected(ctx, TokenKind::RightCurlyBracket)?;
@@ -268,23 +251,6 @@ impl Expr {
                 // if cond { expr1 } else { expr2 }
                 //                          ^^^^^
                 let else_ = Box::new(Expr::parse(ctx, tokens)?);
-
-                if !matches!(
-                    &else_.kind,
-                    ExprKind::Variable { .. }
-                        | ExprKind::Bool { .. }
-                        | ExprKind::BigUInt { .. }
-                        | ExprKind::FieldAccess { .. }
-                        | ExprKind::ArrayAccess { .. }
-                ) {
-                    Err(Error::new(
-                        "parse - if keyword",
-                        ErrorKind::UnexpectedError(
-                            "_else_ branch of ternary operator cannot be more than a variable",
-                        ),
-                        span,
-                    ))?
-                }
 
                 // if cond { expr1 } else { expr2 }
                 //                                ^


### PR DESCRIPTION
- Allows the expressions in `ifelse` block.
- Allow constant field and non constant field in branches.

Related to https://github.com/zksecurity/noname/issues/248