### PR TITLE
Adds tuple type 

### DIFF
--- a/examples/log.no
+++ b/examples/log.no
@@ -13,7 +13,11 @@ fn main(pub public_input: Field) -> Field {
     log(arr);
 
     let thing = Thing { xx : public_input , yy: public_input + 1};
-    log("formatted string with a number {} boolean {} arr {} struct {}" , 1234,true, arr , thing);
+
+    log(thing); 
+    
+    let tup = (1 , true , thing);
+    log("formatted string with a number {} boolean {} arr {} tuple {} struct {}" , 1234 , true, arr, tup, thing);
 
     return public_input + 1;
 }

--- a/examples/tuple.no
+++ b/examples/tuple.no
@@ -1,4 +1,3 @@
-// tuples as field for structs
 struct Thing {
     xx: Field,
     tuple_field: (Field,Bool)
@@ -15,24 +14,34 @@ fn Thing.new(xx: Field , tup: (Field,Bool)) -> (Thing , (Field,Bool)) {
     );
 }
 
+fn generic_array_tuple_test(var : ([[Field;NN];LEN],Bool)) -> (Field , [Field;NN]) {
+    let zero = 0;
+    let result = if var[1] {var[0][LEN - 1][NN - 1]} else { var[0][LEN - 2][NN - 2] };
+    return (result , var[0][LEN - 1]);
+}
+
 // xx should be 0
-fn main(pub xx: Field) -> (Field , (Thing,Bool)){
-    // creation of new tupple with different types
+fn main(pub xx: [Field; 2]) -> Field {
+    // creation of new tuple with different types
     let tup = (1, true);
 
     // create nested tuples 
-    let nested_tup = (1, (true , [1,2,3]));
+    let nested_tup = ((false, [1,2,3]), 1);
     log(nested_tup); // (1, (true , [1,2,3]))
-    // access nested tuples
-    let incr = nested_tup[1][1][0]; // 1
+    
+    let incr = nested_tup[1]; // 1
 
     // tuples can be input to function
-    let mut thing = Thing.new(xx , (xx , xx == 0));
+    let mut thing = Thing.new(xx[1] , (xx[0] , xx[0] == 0));
 
     // you can access a tuple type just like you access a array 
     thing[0].tuple_field[0] += incr;
-    
+    log(thing[0].tuple_field[0]);
+    let new_allocation = [xx,xx];
+    let ret = generic_array_tuple_test((new_allocation, true));
+
     assert_eq(thing[0].tuple_field[0] , 1);
+    log(ret[1]); // logs xx i.e [0,123]
     
-    return (xx ,(thing[0],thing[0].tuple_field[1]));
+    return ret[0];
 }

--- a/examples/tuple.no
+++ b/examples/tuple.no
@@ -1,15 +1,38 @@
-
+// tuples as field for structs
 struct Thing {
     xx: Field,
-    tuple_field: (Field,Field)
+    tuple_field: (Field,Bool)
 }
 
-fn main(pub xx: Field) -> (Field , Thing){
-    // let some = dummy_fn(1,2);
-    let mut tup = (1, true);
-    let mut thing = Thing {xx : xx , tuple_field: (xx , xx+1)};
-    tup[1] = false;
-    log(tup[0]);
-    log(tup[1]);
-    return (xx ,thing);
+// return tuples from functions
+fn Thing.new(xx: Field , tup: (Field,Bool)) -> (Thing , (Field,Bool)) {
+    return (
+        Thing {
+        xx: xx,
+        tuple_field:tup
+        }, 
+        tup
+    );
+}
+
+// xx should be 0
+fn main(pub xx: Field) -> (Field , (Thing,Bool)){
+    // creation of new tupple with different types
+    let tup = (1, true);
+
+    // create nested tuples 
+    let nested_tup = (1, (true , [1,2,3]));
+    log(nested_tup); // (1, (true , [1,2,3]))
+    // access nested tuples
+    let incr = nested_tup[1][1][0]; // 1
+
+    // tuples can be input to function
+    let mut thing = Thing.new(xx , (xx , xx == 0));
+
+    // you can access a tuple type just like you access a array 
+    thing[0].tuple_field[0] += incr;
+    
+    assert_eq(thing[0].tuple_field[0] , 1);
+    
+    return (xx ,(thing[0],thing[0].tuple_field[1]));
 }

--- a/examples/tuple.no
+++ b/examples/tuple.no
@@ -1,0 +1,13 @@
+
+
+struct Thing {
+    xx: Field,
+    tuple_field: (Field,Field)
+}
+
+fn main(pub xx: Field) -> (Field , Thing){
+    // let some = dummy_fn(1,2);
+    // let tup = (1, true);
+    let thing = Thing {xx : xx , tuple_field: (xx , xx+1)};
+    return (xx ,thing);
+}

--- a/examples/tuple.no
+++ b/examples/tuple.no
@@ -1,5 +1,4 @@
 
-
 struct Thing {
     xx: Field,
     tuple_field: (Field,Field)
@@ -7,7 +6,10 @@ struct Thing {
 
 fn main(pub xx: Field) -> (Field , Thing){
     // let some = dummy_fn(1,2);
-    // let tup = (1, true);
-    let thing = Thing {xx : xx , tuple_field: (xx , xx+1)};
+    let mut tup = (1, true);
+    let mut thing = Thing {xx : xx , tuple_field: (xx , xx+1)};
+    tup[1] = false;
+    log(tup[0]);
+    log(tup[1]);
     return (xx ,thing);
 }

--- a/examples/types_array.no
+++ b/examples/types_array.no
@@ -12,7 +12,7 @@ fn main(pub xx: Field, pub yy: Field) {
         xx: 3,
         yy: 4,
     };
-    let things = [thing1, thing2];
+    let things = [thing1, thing2 , 22];
     
     assert_eq(things[0].xx, xx);
     assert_eq(things[1].yy, yy);

--- a/examples/types_array.no
+++ b/examples/types_array.no
@@ -12,7 +12,7 @@ fn main(pub xx: Field, pub yy: Field) {
         xx: 3,
         yy: 4,
     };
-    let things = [thing1, thing2 , 22];
+    let things = [thing1, thing2];
     
     assert_eq(things[0].xx, xx);
     assert_eq(things[1].yy, yy);

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -504,6 +504,8 @@ pub trait Backend: Clone {
                     println!("{dbg_msg}{}", output);
                 }
 
+                Some(TyKind::Tuple(_)) => todo!("Logging of tupple is not implemented yet"),
+
                 None => {
                     return Err(Error::new(
                         "log",

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     helpers::PrettyField,
     imports::FnHandle,
     parser::types::TyKind,
-    utils::{log_array_type, log_custom_type, log_string_type},
+    utils::{log_array_or_tuple_type, log_custom_type, log_string_type},
     var::{ConstOrCell, Value, Var},
     witness::WitnessEnv,
 };
@@ -467,8 +467,20 @@ pub trait Backend: Clone {
 
                 // Array
                 Some(TyKind::Array(b, s)) => {
-                    let (output, remaining) =
-                        log_array_type(self, &var_info.var.cvars, b, *s, witness_env, typed, span)?;
+                    let mut typs = Vec::with_capacity(*s as usize);
+                    for _ in 0..(*s) {
+                        typs.push((**b).clone());
+                    }
+                    let (output, remaining) = log_array_or_tuple_type(
+                        self,
+                        &var_info.var.cvars,
+                        &typs,
+                        *s,
+                        witness_env,
+                        typed,
+                        span,
+                        false,
+                    )?;
                     assert!(remaining.is_empty());
                     println!("{dbg_msg}{}", output);
                 }
@@ -504,8 +516,22 @@ pub trait Backend: Clone {
                     println!("{dbg_msg}{}", output);
                 }
 
-                Some(TyKind::Tuple(_)) => todo!("Logging of tupple is not implemented yet"),
-
+                Some(TyKind::Tuple(typs)) => {
+                    let len = typs.len();
+                    let (output, remaining) = log_array_or_tuple_type(
+                        self,
+                        &var_info.var.cvars,
+                        &typs,
+                        len as u32,
+                        witness_env,
+                        typed,
+                        span,
+                        true,
+                    )
+                    .unwrap();
+                    assert!(remaining.is_empty());
+                    println!("{dbg_msg}{}", output);
+                }
                 None => {
                     return Err(Error::new(
                         "log",

--- a/src/circuit_writer/ir.rs
+++ b/src/circuit_writer/ir.rs
@@ -445,23 +445,23 @@ impl<B: Backend> IRWriter<B> {
                     ForLoopArgument::Iterator(iterator) => {
                         let iterator_var = self
                             .compute_expr(fn_env, iterator)?
-                            .expect("array access on non-array");
+                            .expect("container access on non-container");
 
                         let array_typ = self
                             .expr_type(iterator)
                             .cloned()
-                            .expect("cannot find type of array");
+                            .expect("cannot find type of container");
 
                         let (elem_type, array_len) = match array_typ {
                             TyKind::Array(ty, array_len) => (ty, array_len),
                             _ => Err(Error::new(
                                 "compile-stmt",
-                                ErrorKind::UnexpectedError("expected array"),
+                                ErrorKind::UnexpectedError("expected container"),
                                 stmt.span,
                             ))?,
                         };
 
-                        // compute the size of each element in the array
+                        // compute the size of each element in the container
                         let len = self.size_of(&elem_type);
 
                         for idx in 0..array_len {
@@ -972,11 +972,11 @@ impl<B: Backend> IRWriter<B> {
                 Ok(Some(res))
             }
 
-            ExprKind::ArrayAccess { array, idx } => {
-                // retrieve var of array
+            ExprKind::ArrayOrTupleAccess { container, idx } => {
+                // retrieve var of container
                 let var = self
-                    .compute_expr(fn_env, array)?
-                    .expect("array access on non-array");
+                    .compute_expr(fn_env, container)?
+                    .expect("container access on non-container");
 
                 // compute the index
                 let idx_var = self
@@ -987,10 +987,12 @@ impl<B: Backend> IRWriter<B> {
                     .ok_or_else(|| self.error(ErrorKind::ExpectedConstant, expr.span))?;
                 let idx: usize = idx.try_into().unwrap();
 
-                // retrieve the type of the elements in the array
-                let array_typ = self.expr_type(array).expect("cannot find type of array");
+                // retrieve the type of the elements in the container
+                let container_typ = self
+                    .expr_type(container)
+                    .expect("cannot find type of container");
 
-                let elem_type = match array_typ {
+                let elem_type = match container_typ {
                     TyKind::Array(ty, array_len) => {
                         if idx >= (*array_len as usize) {
                             return Err(self.error(
@@ -998,17 +1000,19 @@ impl<B: Backend> IRWriter<B> {
                                 expr.span,
                             ));
                         }
-                        ty
+                        (**ty).clone()
                     }
+                    //TODO: Add tuple index out of bounds error
+                    TyKind::Tuple(typs) => typs[idx].clone(),
                     _ => Err(Error::new(
                         "compute-expr",
-                        ErrorKind::UnexpectedError("expected array"),
+                        ErrorKind::UnexpectedError("expected container"),
                         expr.span,
                     ))?,
                 };
 
-                // compute the size of each element in the array
-                let len = self.size_of(elem_type);
+                // compute the size of each element in the container
+                let len = self.size_of(&elem_type);
 
                 // compute the real index
                 let start = idx * len;

--- a/src/circuit_writer/ir.rs
+++ b/src/circuit_writer/ir.rs
@@ -1074,6 +1074,20 @@ impl<B: Backend> IRWriter<B> {
                 let var = VarOrRef::Var(Var::new(cvars, expr.span));
                 Ok(Some(var))
             }
+
+            ExprKind::TupleDeclaration(items) => {
+                let mut cvars = vec![];
+
+                for item in items {
+                    let var = self.compute_expr(fn_env, item)?.unwrap();
+                    let to_extend = var.value(self, fn_env).cvars.clone();
+                    cvars.extend(to_extend);
+                }
+
+                let var = VarOrRef::Var(Var::new(cvars, expr.span));
+
+                Ok(Some(var))
+            }
         }
     }
 

--- a/src/circuit_writer/ir.rs
+++ b/src/circuit_writer/ir.rs
@@ -992,9 +992,9 @@ impl<B: Backend> IRWriter<B> {
                     .expr_type(container)
                     .expect("cannot find type of container");
 
-                // real starting index for narrowing the var depends on the cotainer
-                // for arrays it is just idx * ele_size as all elements are of same size
-                // while for tuples we have to sum the sizes of all types up till that index
+                // actual starting index for narrowing the var depends on the cotainer
+                // for arrays it is just idx * elem_size as all elements are of same size
+                // while for tuples we have to sum the sizes of all types up to that index
                 let (start, len) = match container_typ {
                     TyKind::Array(ty, array_len) => {
                         if idx >= (*array_len as usize) {

--- a/src/circuit_writer/writer.rs
+++ b/src/circuit_writer/writer.rs
@@ -756,9 +756,9 @@ impl<B: Backend> CircuitWriter<B> {
                     .expr_type(container)
                     .expect("cannot find type of container");
 
-                // real starting index for narrowing the var depends on the cotainer
-                // for arrays it is just idx * ele_size as all elements are of same size
-                // while for tuples we have to sum the sizes of all types up till that index
+                // actual starting index for narrowing the var depends on the cotainer
+                // for arrays it is just idx * elem_size as all elements are of same size
+                // while for tuples we have to sum the sizes of all types up to that index
                 let (start, len) = match container_typ {
                     TyKind::Array(ty, array_len) => {
                         if idx >= (*array_len as usize) {
@@ -773,11 +773,11 @@ impl<B: Backend> CircuitWriter<B> {
                     }
 
                     TyKind::Tuple(typs) => {
-                        let mut starting_idx = 0;
+                        let mut start = 0;
                         for i in 0..idx {
-                            starting_idx += self.size_of(&typs[i]);
+                            start += self.size_of(&typs[i]);
                         }
-                        (starting_idx, self.size_of(&typs[idx]))
+                        (start, self.size_of(&typs[idx]))
                     }
                     _ => Err(Error::new(
                         "compute-expr",

--- a/src/error.rs
+++ b/src/error.rs
@@ -268,6 +268,9 @@ pub enum ErrorKind {
     #[error("array accessed at index {0} is out of bounds (max allowed index is {1})")]
     ArrayIndexOutOfBounds(usize, usize),
 
+    #[error("tuple accessed at index {0} is out of bounds (max allowed index is {1})")]
+    TupleIndexOutofBounds(usize, usize),
+
     #[error(
         "one-letter variables or types are not allowed. Best practice is to use descriptive names"
     )]

--- a/src/error.rs
+++ b/src/error.rs
@@ -327,8 +327,8 @@ pub enum ErrorKind {
     #[error("field access can only be applied on custom structs")]
     FieldAccessOnNonCustomStruct,
 
-    #[error("array access can only be performed on arrays")]
-    ArrayAccessOnNonArray,
+    #[error("array like access can only be performed on arrays or tuples")]
+    AccessOnNonCollection,
 
     #[error("struct `{0}` does not exist (are you sure it is defined?)")]
     UndefinedStruct(String),

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -151,6 +151,22 @@ impl<B: Backend> CompiledCircuit<B> {
 
                 Ok(res)
             }
+            // parsing for tuple function inputs from json
+            (TyKind::Tuple(types), Value::Array(values)) => {
+                if values.len() != types.len() {
+                    Err(ParsingError::ArraySizeMismatch(
+                        values.len(),
+                        types.len() as usize,
+                    ))?
+                }
+                // making a vec with capacity allows for less number of reallocations
+                let mut res = Vec::with_capacity(values.len());
+                for (ty, val) in types.iter().zip(values) {
+                    let el = self.parse_single_input(val, ty)?;
+                    res.extend(el);
+                }
+                Ok(res)
+            }
             (expected, observed) => {
                 return Err(ParsingError::MismatchJsonArgument(
                     expected.clone(),

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -1164,7 +1164,7 @@ fn monomorphize_expr<B: Backend>(
         }
 
         ExprKind::TupleDeclaration(items) => {
-            // checking if the size of tuple same is as maximum size of an array
+            // checking the size of the tuple
             let _: u32 = items.len().try_into().expect("tuple too large");
 
             let items_mono: Vec<ExprMonoInfo> = items

--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -53,7 +53,7 @@ impl PropagatedConstant {
     pub fn as_array(&self) -> Vec<BigUint> {
         match self {
             PropagatedConstant::Array(v) => v.iter().map(|c| c.as_single()).collect(),
-            _ => panic!("expected container value"),
+            _ => panic!("expected array value"),
         }
     }
 
@@ -227,7 +227,7 @@ impl FnSig {
                 let val = sym.eval(&self.generics, &ctx.tast);
                 TyKind::Array(
                     Box::new(self.resolve_type(ty, ctx)),
-                    val.to_u32().expect("container size exceeded u32"),
+                    val.to_u32().expect("array size exceeded u32"),
                 )
             }
             _ => typ.clone(),
@@ -1295,7 +1295,7 @@ pub fn monomorphize_stmt<B: Backend>(
                         _ => Err(Error::new(
                             "Monomorphize Stmt - ForLoopArgument",
                             ErrorKind::UnexpectedError(
-                                "Expected container while monomorphizing iterator's type",
+                                "Expected array while monomorphizing iterator's type",
                             ),
                             stmt.span,
                         ))?,

--- a/src/name_resolution/context.rs
+++ b/src/name_resolution/context.rs
@@ -134,6 +134,11 @@ impl NameResCtx {
             TyKind::GenericSizedArray(typ_kind, _) => self.resolve_typ_kind(typ_kind)?,
             TyKind::Bool => (),
             TyKind::String { .. } => (),
+            TyKind::Tuple(typs) => {
+                typs.iter_mut()
+                    .for_each(|typ| self.resolve_typ_kind(typ).unwrap());
+                ()
+            }
         };
 
         Ok(())

--- a/src/name_resolution/expr.rs
+++ b/src/name_resolution/expr.rs
@@ -105,6 +105,11 @@ impl NameResCtx {
                 self.resolve_expr(then_)?;
                 self.resolve_expr(else_)?;
             }
+            ExprKind::TupleDeclaration(items) => {
+                for expr in items {
+                    self.resolve_expr(expr)?;
+                }
+            }
         };
 
         Ok(())

--- a/src/name_resolution/expr.rs
+++ b/src/name_resolution/expr.rs
@@ -71,8 +71,8 @@ impl NameResCtx {
             ExprKind::Variable { module, name: _ } => {
                 self.resolve(module, false)?;
             }
-            ExprKind::ArrayAccess { array, idx } => {
-                self.resolve_expr(array)?;
+            ExprKind::ArrayOrTupleAccess { container, idx } => {
+                self.resolve_expr(container)?;
                 self.resolve_expr(idx)?;
             }
             ExprKind::ArrayDeclaration(items) => {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -132,8 +132,6 @@ pub enum ExprKind {
 
     ///Tuple Declaration
     TupleDeclaration(Vec<Expr>),
-    // A tuple access through tuple[idx]
-    // TupleAccess { tuple: Box<Expr>, idx: Box<Expr> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -343,7 +343,7 @@ impl TyKind {
             (TyKind::String { .. }, TyKind::String { .. }) => true,
             (x, y) if x == y => true,
             (TyKind::Tuple(lhs), TyKind::Tuple(rhs)) => {
-                // if len is not eqaul do not to do the match computation just return false
+                // early exit the lenght do not match
                 if lhs.len() == rhs.len() {
                     let match_items = lhs
                         .iter()

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -141,6 +141,32 @@ fn assert_eq_values<B: Backend>(
         TyKind::GenericSizedArray(_, _) => {
             unreachable!("GenericSizedArray should be monomorphized")
         }
+
+        TyKind::String(_) => todo!("String is not implemented yet"),
+
+        TyKind::Tuple(typs) => {
+            let mut offset = 0;
+            for ty in typs {
+                let element_size = compiler.size_of(ty);
+                let mut element_comparisions = assert_eq_values(
+                    compiler,
+                    &VarInfo::new(
+                        Var::new(lhs_info.var.range(offset, element_size).to_vec(), span),
+                        false,
+                        Some(ty.clone()),
+                    ),
+                    &VarInfo::new(
+                        Var::new(rhs_info.var.range(offset, element_size).to_vec(), span),
+                        false,
+                        Some(ty.clone()),
+                    ),
+                    ty,
+                    span,
+                );
+                comparisons.append(&mut element_comparisions);
+                offset += element_size;
+            }
+        }
     }
 
     comparisons

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -281,16 +281,16 @@ impl<B: Backend> TypeChecker<B> {
                         name.value.clone()
                     }
 
-                    // `array[idx] = <rhs>`
+                    // `array[idx] = <rhs>` or `tuple[idx] = rhs`
                     ExprKind::ArrayOrTupleAccess { container, idx } => {
-                        // get variable behind array
+                        // get variable behind container
                         let cotainer_node = self
                             .compute_type(container, typed_fn_env)?
-                            .expect("type-checker bug: array access on an empty var");
+                            .expect("type-checker bug: array or tuple access on an empty var");
 
                         cotainer_node
                             .var_name
-                            .expect("anonymous array access cannot be mutated")
+                            .expect("anonymous array or tuple access cannot be mutated")
                     }
 
                     // `struct.field = <rhs>`
@@ -531,7 +531,6 @@ impl<B: Backend> TypeChecker<B> {
                 let typs: Vec<TyKind> = items
                     .iter()
                     .map(|item| {
-                        //some better error handling here in case type_not found
                         self.compute_type(item, typed_fn_env)
                             .unwrap()
                             .expect("expected some val")

--- a/src/type_checker/checker.rs
+++ b/src/type_checker/checker.rs
@@ -518,6 +518,21 @@ impl<B: Backend> TypeChecker<B> {
                 let res = ExprTyInfo::new_anon(TyKind::Array(Box::new(tykind), len));
                 Some(res)
             }
+            ExprKind::TupleDeclaration(items) => {
+                // restricting tupple len as array len
+                let _: u32 = items.len().try_into().expect("tupple too large");
+                let typs: Vec<TyKind> = items
+                    .iter()
+                    .map(|item| {
+                        //some better error handling here in case type_not found
+                        self.compute_type(item, typed_fn_env)
+                            .unwrap()
+                            .expect("expected some val")
+                            .typ
+                    })
+                    .collect();
+                Some(ExprTyInfo::new_anon(TyKind::Tuple(typs)))
+            }
 
             ExprKind::IfElse { cond, then_, else_ } => {
                 // cond can only be a boolean

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -488,6 +488,7 @@ impl<B: Backend> TypeChecker<B> {
                                 TyKind::Field { constant: false }
                                 | TyKind::Custom { .. }
                                 | TyKind::Array(_, _)
+                                | TyKind::Tuple(_)
                                 | TyKind::Bool => {
                                     typed_fn_env.store_type(
                                         "public_output".to_string(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -190,6 +190,8 @@ pub fn log_string_type<B: Backend>(
                 unreachable!("GenericSizedArray should be monomorphized")
             }
             Some(TyKind::String(_)) => todo!("String cannot be in circuit yet"),
+
+            Some(TyKind::Tuple(_)) => todo!("logging is not implemented in tuple"),
             None => {
                 return Err(Error::new(
                     "log",
@@ -295,6 +297,8 @@ pub fn log_array_type<B: Backend>(
         }
 
         TyKind::String(_) => todo!("String type cannot be used in circuits!"),
+
+        TyKind::Tuple(_) => todo!("Logging is not implemented for tupple"),
     }
 }
 pub fn log_custom_type<B: Backend>(
@@ -379,6 +383,7 @@ pub fn log_custom_type<B: Backend>(
             TyKind::String(s) => {
                 todo!("String cannot be a type for customs it is only for logging")
             }
+            TyKind::Tuple(_) => todo!("Logging for tuple type is not implemented"),
         }
     }
 


### PR DESCRIPTION
closes #255 

the example file can be found here [tuple.no](https://github.com/0xnullifier/noname/blob/feat-tuple/examples/tuple.no) this works and runs the output is:
<img width="876" alt="image" src="https://github.com/user-attachments/assets/b8c5c6a0-ef25-4f4c-a4b0-024c785546d6" />


I have not implemented destructuring as that is potentially another pr.

The code is pretty much identical to array type as tuple is just a multi-type array

and also as @mimoo suggested that we should keep the tuple access similar to array access. I have just changes the code for `ExprKind::ArrayAccess` to `ExprKind::ArrayOrTupleAccess` as they are identical at lexer level and dealt with this at type checker and writer.

it also refactors the array logging and combines it to array or tuple logging