### PR TITLE
bug-fix: correct type matching in if-else expression

### DIFF
--- a/src/mast/mod.rs
+++ b/src/mast/mod.rs
@@ -1063,7 +1063,17 @@ fn monomorphize_expr<B: Backend>(
             let else_mono = monomorphize_expr(ctx, else_, mono_fn_env)?;
 
             // make sure that the type of then_ and else_ match
-            if then_mono.typ != else_mono.typ {
+            let is_match = match (&then_mono.typ, &else_mono.typ) {
+                // generics not allowed as they should have been monomorphized
+                (Some(then_typ), Some(else_typ)) => then_typ.match_expected(else_typ, true),
+                _ => Err(Error::new(
+                    "If-Else Monomorphization",
+                    ErrorKind::UnexpectedError("Could not resolve type for the `if-else` branch"),
+                    expr.span,
+                ))?,
+            };
+
+            if !is_match {
                 Err(Error::new(
                     "If-Else Monomorphization",
                     ErrorKind::UnexpectedError(


### PR DESCRIPTION
found this bug while implementing smt in stdlib [here](https://github.com/zksecurity/noname/pull/249#issuecomment-2604436495)