### PR TITLE
update action: peaceiris/actions-gh-pages from v3 to v4

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
           mv ./target/doc ./book/book/rustdoc
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book


### PR DESCRIPTION
### Description
This PR updates the `peaceiris/actions-gh-pages` GitHub Action from version `v3` to the latest stable version `v4`.  
The update ensures compatibility with the latest GitHub Actions runtime and includes performance improvements and bug fixes introduced in v4.

Reference: https://github.com/peaceiris/actions-gh-pages/releases