### PR TITLE
Update documentation link to the current Noname book URL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! This is a high-level language to write circuits that you can prove in kimchi.
-//! Refer to the [book](https://mimoo.github.io/noname/) for more information.
+//! Refer to the [book](https://zksecurity.github.io/noname/) for more information.
 //!
 
 pub mod backends;


### PR DESCRIPTION
Replaced the outdated link to the Noname book (mimoo.github.io/noname) with the new official URL (zksecurity.github.io/noname) in the crate-level documentation comment. This ensures users are directed to the latest and maintained documentation for the Noname language.