### PR TITLE
fix(docs): correct typos and grammar in comments across modules

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -458,7 +458,7 @@ impl Token {
                     tokens.push(TokenKind::Question.new_token(ctx, 1));
                 }
                 '"' => {
-                    //TODO: Add error handling if qoute not closed
+                    //TODO: Add error handling if quote not closed
                     let literal: String = chars.by_ref().take_while(|&char| char != '"').collect();
                     let len = literal.len();
                     tokens.push(TokenKind::StringLiteral(literal).new_token(ctx, len));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -35,7 +35,7 @@ pub use structs::{CustomType, StructDef};
 //~ city := [ sign ] "," { house }
 //~         ^            ^
 //~         optional     |
-//~                     0r or more houses
+//~                     0 or more houses
 //~
 //~ sign := /a-zA-Z_/
 //~         ^

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -297,7 +297,7 @@ pub enum TyKind {
     /// After monomorphized, it will be converted to `Array`.
     GenericSizedArray(Box<TyKind>, Symbolic),
 
-    /// A string  type current purpose it to pass around for logging
+    /// A string type current purpose it to pass around for logging
     String(String),
 }
 
@@ -712,7 +712,7 @@ impl FnSig {
     }
 
     /// Returns the monomorphized function name,
-    /// using the patter: `fn_full_qualified_name#generic1=value1#generic2=value2`
+    /// using the pattern: `fn_full_qualified_name#generic1=value1#generic2=value2`
     pub fn monomorphized_name(&self) -> Ident {
         let mut name = self.name.clone();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ use tower_http::services::ServeDir;
 use crate::cli::packages::path_to_release_dir;
 
 //
-// The interface for the rest of the compiler which doens't use async/await
+// The interface for the rest of the compiler which doesn't use async/await
 //
 
 #[derive(Clone)]

--- a/src/stdlib/builtins.rs
+++ b/src/stdlib/builtins.rs
@@ -59,7 +59,7 @@ fn assert_eq_values<B: Backend>(
     let mut comparisons = Vec::new();
 
     match typ {
-        // Field and Bool has the same logic
+        // Field and Bool have the same logic
         TyKind::Field { .. } | TyKind::Bool | TyKind::String(..) => {
             let lhs_var = &lhs_info.var[0];
             let rhs_var = &rhs_info.var[0];


### PR DESCRIPTION
src/lexer/mod.rs: fixed typo in TODO comment (qoute → quote).

src/parser/mod.rs: fixed grammar in grammar-rule comment (0r → 0).

src/parser/types.rs: corrected typos (patter → pattern, extra space in string type).

src/server/mod.rs: fixed typo (doens't → doesn't).

src/stdlib/builtins.rs: corrected verb form (has → have).