### PR TITLE
 chore: upgrade rust-cache to v2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
 
       # https://github.com/Swatinem/rust-cache
       - name: Cache Rust stuff
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
 Updates `Swatinem/rust-cache` from v1 to v2 in the CI workflow.

  v2 brings improved caching performance through better cache key generation and smarter restoration logic. The action is
  backward compatible and requires no configuration changes.